### PR TITLE
fix(yay): drop --editmenu to fix "only one operation" conflict

### DIFF
--- a/internal/yay/yay.go
+++ b/internal/yay/yay.go
@@ -88,7 +88,7 @@ func injectEditor(argv []string, self string) []string {
 			editor = cand
 		}
 	}
-	return append(argv, "--editor", editor, "--editmenu", "--answeredit", "All")
+	return append(argv, "--editor", editor, "--answeredit", "All")
 }
 
 func fileExists(p string) bool {


### PR DESCRIPTION
## Summary

- `syay -Syu` was failing with `only one operation may be used at a time`
- Root cause: `--editmenu` is parsed by modern yay versions as an **operation** (not a config flag), which conflicts with `-S` from `-Syu`
- Fix: remove `--editmenu` from the injected args — `--answeredit All` alone is sufficient to force yay to invoke the editor for every AUR package

## Test plan

- [ ] Build from source: `make build && ln -sf "$(pwd)/aurscan" /tmp/syay`
- [ ] Run `syay -Syu` — should no longer error with "only one operation may be used at a time"
- [ ] Confirm aurscan still scans packages before build (editor hook is still invoked)
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)