### PR TITLE
Add portable AUR update scan files

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,27 @@ syay <anything>             # normal yay usage; the scanner gates AUR builds
 aurscan <pkgname> [...]     # standalone scan (fetches the AUR snapshot in memory)
 aurscan ./builddir          # scan a local build directory
 aurscan --update-check      # audit pending AUR updates without installing anything
+aurscan --gen-file          # write pending AUR updates to ./aurscan.paclist
+aurscan --scan-file         # scan packages listed in ./aurscan.paclist
 ```
+
+**Offline admin workflow.** If you maintain machines that do not have an LLM
+backend configured, install aurscan there and run:
+
+```bash
+aurscan --gen-file
+```
+
+That overwrites `./aurscan.paclist` with a structured list of pending AUR
+updates from `yay -Qua`. Copy that single file to your scanner machine and run:
+
+```bash
+aurscan --scan-file
+```
+
+The scan command requires `aurscan.paclist` in the current directory, validates
+that it is an aurscan-generated file, and scans the listed packages through the
+same recursive AUR scanner used by `--update-check`.
 
 When a package is flagged:
 

--- a/cmd/aurscan/main.go
+++ b/cmd/aurscan/main.go
@@ -6,6 +6,8 @@
 //
 //	aurscan <pkgname|./dir> [...]   scan AUR package(s) / local build dir(s)
 //	aurscan --update-check          scan pending AUR updates (yay -Qua)
+//	aurscan --gen-file              write pending AUR updates to aurscan.paclist
+//	aurscan --scan-file             scan packages listed in ./aurscan.paclist
 //	aurscan --edit-hook <files...>  $EDITOR-replacement gate for yay
 //	syay <yay args...>              transparent yay wrapper (symlink)
 //	aurscan-edit <files...>         edit-hook (symlink; what syay points yay at)
@@ -30,6 +32,8 @@ import (
 const usage = `usage:
   aurscan <pkgname|./dir> [...]    scan AUR package(s) / local build dir(s)
   aurscan --update-check           scan pending AUR updates (yay -Qua)
+  aurscan --gen-file               write pending AUR updates to ./aurscan.paclist
+  aurscan --scan-file              scan packages listed in ./aurscan.paclist
   aurscan --rules-only <...>       static rules only, no LLM call (free, offline)
   aurscan --edit-hook <files...>   gate mode (yay invokes this as its editor)
   aurscan --version                print version and exit
@@ -76,6 +80,33 @@ func main() {
 	switch args[0] {
 	case "--update-check":
 		results = updateCheck()
+	case "--gen-file":
+		if len(args) != 1 {
+			fmt.Fprintln(os.Stderr, ui.Red("error: ")+"--gen-file does not accept arguments")
+			os.Exit(3)
+		}
+		n, err := writePaclistFromYay()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, ui.Red("error: ")+err.Error())
+			os.Exit(3)
+		}
+		fmt.Printf("%s wrote %d pending AUR update(s) to %s\n", ui.Green("OK:"), n, paclistFile)
+		return
+	case "--scan-file":
+		if len(args) != 1 {
+			fmt.Fprintln(os.Stderr, ui.Red("error: ")+"--scan-file does not accept arguments")
+			os.Exit(3)
+		}
+		names, err := readPaclistPackages()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, ui.Red("error: ")+err.Error())
+			os.Exit(3)
+		}
+		if len(names) == 0 {
+			fmt.Println(ui.Green("No pending AUR updates in ") + paclistFile + ".")
+			return
+		}
+		results = aur.ScanRecursive(names, ui.Progress)
 	default:
 		results = scanArgs(args)
 	}

--- a/cmd/aurscan/paclist.go
+++ b/cmd/aurscan/paclist.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"time"
+)
+
+const (
+	paclistFile   = "aurscan.paclist"
+	paclistFormat = "aurscan-paclist-v1"
+)
+
+var packageNameRe = regexp.MustCompile(`^[A-Za-z0-9@._+-]+$`)
+
+type paclist struct {
+	Format      string           `json:"format"`
+	GeneratedAt string           `json:"generated_at"`
+	Host        string           `json:"host"`
+	Source      string           `json:"source"`
+	Packages    []paclistPackage `json:"packages"`
+}
+
+type paclistPackage struct {
+	Name      string `json:"name"`
+	Current   string `json:"current,omitempty"`
+	Available string `json:"available,omitempty"`
+	Raw       string `json:"raw"`
+}
+
+func writePaclistFromYay() (int, error) {
+	out, err := run("yay", "-Qua")
+	if err != nil {
+		return 0, fmt.Errorf("yay -Qua failed: %w", err)
+	}
+	list, err := newPaclist(out)
+	if err != nil {
+		return 0, err
+	}
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(list); err != nil {
+		return 0, err
+	}
+	if err := os.WriteFile(paclistFile, buf.Bytes(), 0o644); err != nil {
+		return 0, err
+	}
+	return len(list.Packages), nil
+}
+
+func readPaclistPackages() ([]string, error) {
+	b, err := os.ReadFile(paclistFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("%s not found in the current directory", paclistFile)
+		}
+		return nil, err
+	}
+	var list paclist
+	if err := json.Unmarshal(b, &list); err != nil {
+		return nil, fmt.Errorf("%s is not valid JSON: %w", paclistFile, err)
+	}
+	if list.Format != paclistFormat {
+		return nil, fmt.Errorf("%s has unsupported format %q", paclistFile, list.Format)
+	}
+	names := make([]string, 0, len(list.Packages))
+	seen := map[string]bool{}
+	for _, p := range list.Packages {
+		if err := validatePackageName(p.Name); err != nil {
+			return nil, fmt.Errorf("%s contains invalid package name %q: %w", paclistFile, p.Name, err)
+		}
+		if !seen[p.Name] {
+			seen[p.Name] = true
+			names = append(names, p.Name)
+		}
+	}
+	return names, nil
+}
+
+func newPaclist(yayOutput string) (paclist, error) {
+	host, _ := os.Hostname()
+	list := paclist{
+		Format:      paclistFormat,
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		Host:        host,
+		Source:      "yay -Qua",
+		Packages:    []paclistPackage{},
+	}
+	for _, line := range splitLines(yayOutput) {
+		pkg, ok := parseYayUpdateLine(line)
+		if !ok {
+			continue
+		}
+		if err := validatePackageName(pkg.Name); err != nil {
+			return paclist{}, fmt.Errorf("yay returned invalid package name %q: %w", pkg.Name, err)
+		}
+		list.Packages = append(list.Packages, pkg)
+	}
+	return list, nil
+}
+
+func parseYayUpdateLine(line string) (paclistPackage, bool) {
+	f := fields(line)
+	if len(f) == 0 {
+		return paclistPackage{}, false
+	}
+	name := f[0]
+	for i, c := range name {
+		if c == '/' {
+			name = name[i+1:]
+			break
+		}
+	}
+	pkg := paclistPackage{Name: name, Raw: line}
+	if len(f) > 1 {
+		pkg.Current = f[1]
+	}
+	for i := 2; i+1 < len(f); i++ {
+		if f[i] == "->" {
+			pkg.Available = f[i+1]
+			break
+		}
+	}
+	return pkg, true
+}
+
+func validatePackageName(name string) error {
+	if name == "" {
+		return fmt.Errorf("empty name")
+	}
+	if !packageNameRe.MatchString(name) {
+		return fmt.Errorf("allowed characters are letters, numbers, @, dot, underscore, plus, and hyphen")
+	}
+	return nil
+}

--- a/cmd/aurscan/paclist_test.go
+++ b/cmd/aurscan/paclist_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewPaclistParsesYayOutput(t *testing.T) {
+	list, err := newPaclist("aur/orca-git 49.beta.r12-2 -> 49.beta.r13-1\nbrave-bin 1.2.3-1 -> 1.2.4-1\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if list.Format != paclistFormat {
+		t.Fatalf("format = %q, want %q", list.Format, paclistFormat)
+	}
+	if got, want := len(list.Packages), 2; got != want {
+		t.Fatalf("package count = %d, want %d", got, want)
+	}
+	if got, want := list.Packages[0].Name, "orca-git"; got != want {
+		t.Fatalf("first package name = %q, want %q", got, want)
+	}
+	if got, want := list.Packages[0].Available, "49.beta.r13-1"; got != want {
+		t.Fatalf("available version = %q, want %q", got, want)
+	}
+}
+
+func TestNewPaclistRejectsBadPackageName(t *testing.T) {
+	if _, err := newPaclist("bad/name/extra 1 -> 2\n"); err == nil {
+		t.Fatal("expected invalid package name error")
+	}
+}
+
+func TestReadPaclistPackages(t *testing.T) {
+	dir := t.TempDir()
+	oldwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldwd) })
+
+	data := []byte(`{
+  "format": "aurscan-paclist-v1",
+  "generated_at": "2026-06-14T16:30:00Z",
+  "host": "example",
+  "source": "yay -Qua",
+  "packages": [
+    {"name": "orca-git", "current": "1", "available": "2", "raw": "orca-git 1 -> 2"},
+    {"name": "orca-git", "current": "1", "available": "2", "raw": "orca-git 1 -> 2"},
+    {"name": "brave-bin", "current": "3", "available": "4", "raw": "brave-bin 3 -> 4"}
+  ]
+}`)
+	if err := os.WriteFile(filepath.Join(dir, paclistFile), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	names, err := readPaclistPackages()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := len(names), 2; got != want {
+		t.Fatalf("package count = %d, want %d", got, want)
+	}
+	if names[0] != "orca-git" || names[1] != "brave-bin" {
+		t.Fatalf("names = %#v, want orca-git/brave-bin", names)
+	}
+}
+
+func TestReadPaclistPackagesRequiresFile(t *testing.T) {
+	dir := t.TempDir()
+	oldwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldwd) })
+
+	if _, err := readPaclistPackages(); err == nil {
+		t.Fatal("expected missing paclist error")
+	}
+}


### PR DESCRIPTION
## Summary
- add --gen-file and --scan-file support for portable AUR update-list workflows
- document the generated file workflow
- add paclist parsing tests

## Tests
- GOCACHE=/tmp/aurscan-gocache go test -count=1 ./...

Developed with LLM assistance.