### PR TITLE
feat(scan): omit model field when AURSCAN_OPENAI_MODEL is unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- The OpenAI-compatible backend no longer sends a `model` field when
+  `AURSCAN_OPENAI_MODEL` is unset (previously it sent the placeholder
+  `default-model`). This lets a routing proxy such as LiteLLM select the model
+  itself, so models can be switched at the proxy without editing env vars or
+  restarting. Set `AURSCAN_OPENAI_MODEL` to pin a specific model on servers that
+  require one.
+
 ### Fixed
 - **paru interactive build decision now works (#3).** The `--prebuild` hook
   prompts over `/dev/tty`, so you can abort or override a flagged package even

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Auto-detected, in this order — **option 1 needs no API key at all**:
 1. **Claude Code CLI** (`claude`) in `PATH` and logged in → uses your existing Claude subscription. Reports **exact cost** per scan.
 2. **`ANTHROPIC_API_KEY`** → direct API (`claude-sonnet-4-6` by default). Reports exact tokens; cost computed from a built-in price table.
 3. **Codex CLI** (`codex`) in `PATH` and logged in → uses your existing Codex subscription. Tokens and cost are estimated/not available from the CLI output.
-4. **Local / self-hosted model** via `AURSCAN_OPENAI_URL` → any OpenAI-compatible `/chat/completions` endpoint (**llama.cpp, Ollama, vLLM, LocalAI**). Fully private; set `AURSCAN_OPENAI_URL_FALLBACK` for automatic failover (e.g. GPU host → local CPU). The model is swappable via `AURSCAN_OPENAI_MODEL`, and an API key (for proxies like **LiteLLM**) via `AURSCAN_OPENAI_API_KEY` (or the conventional `OPENAI_API_KEY`).
+4. **Local / self-hosted model** via `AURSCAN_OPENAI_URL` → any OpenAI-compatible `/chat/completions` endpoint (**llama.cpp, Ollama, vLLM, LocalAI**). Fully private; set `AURSCAN_OPENAI_URL_FALLBACK` for automatic failover (e.g. GPU host → local CPU). The model is sent only when `AURSCAN_OPENAI_MODEL` is set; leave it unset and a routing proxy can select the model itself. An API key (for proxies like **LiteLLM**) goes in `AURSCAN_OPENAI_API_KEY` (or the conventional `OPENAI_API_KEY`).
 5. **`AURSCAN_BACKEND=/path/to/cmd`** → any executable that reads the prompt on stdin and prints the reply on stdout.
 6. **No backend at all** → static rules still run and block on critical matches.
 
@@ -159,6 +159,17 @@ For a **LiteLLM** proxy:
 set -Ux AURSCAN_BACKEND openai
 set -Ux AURSCAN_OPENAI_URL http://localhost:4000/v1/chat/completions
 set -Ux AURSCAN_OPENAI_MODEL gpt-4o-mini        # whatever your LiteLLM config exposes
+set -Ux AURSCAN_OPENAI_API_KEY sk-your-litellm-key
+```
+
+To let a **routing proxy** (LiteLLM, etc.) pick the model itself — e.g. so you
+can switch models at the proxy without editing env vars or restarting aurscan —
+point `AURSCAN_OPENAI_URL` at the proxy and set **no** `AURSCAN_OPENAI_MODEL`:
+
+```fish
+set -Ux AURSCAN_BACKEND openai
+set -Ux AURSCAN_OPENAI_URL http://localhost:4000/v1/chat/completions
+# no AURSCAN_OPENAI_MODEL — proxy decides
 set -Ux AURSCAN_OPENAI_API_KEY sk-your-litellm-key
 ```
 
@@ -332,7 +343,7 @@ Override the API price table (USD per million tokens) so you never depend on a s
 | `AURSCAN_MAX_PKGS` | `25` | recursion cap for AUR dependency scanning |
 | `AURSCAN_PRICE_IN` / `AURSCAN_PRICE_OUT` | built-in | USD per million tokens |
 | `AURSCAN_OPENAI_URL` / `_FALLBACK` | — | OpenAI-compatible endpoint(s) for a local model |
-| `AURSCAN_OPENAI_MODEL` | `default-model` | model name sent to the local endpoint |
+| `AURSCAN_OPENAI_MODEL` | unset / omitted | no `model` field is sent by default, letting a routing proxy (LiteLLM, etc.) pick the model; set it to pin a specific model on servers that require one |
 | `AURSCAN_OPENAI_API_KEY` | `OPENAI_API_KEY` | bearer token for the endpoint (e.g. LiteLLM); omit for open servers |
 | `AURSCAN_TIMEOUT` | `180` | per-request budget in **seconds**; raise it for slow CPU-only local models |
 | `AURSCAN_INSTRUCTIONS` | — | path to extra auditor instructions (appended) |

--- a/internal/scan/llm.go
+++ b/internal/scan/llm.go
@@ -332,13 +332,12 @@ func callOpenAI(parent context.Context, to time.Duration, instructions, content 
 	if fb := os.Getenv("AURSCAN_OPENAI_URL_FALLBACK"); fb != "" {
 		urls = append(urls, fb)
 	}
-	model := os.Getenv("AURSCAN_OPENAI_MODEL")
-	if model == "" {
-		model = "default-model"
-	}
 	apiKey := openAIKey()
-	body, _ := json.Marshal(map[string]any{
-		"model":           model,
+	// The model is sent only when AURSCAN_OPENAI_MODEL is set. Leaving it out
+	// lets a routing proxy (LiteLLM and similar) select the model itself, so you
+	// can switch models at the proxy without touching this env var or restarting.
+	// Set AURSCAN_OPENAI_MODEL for servers that require an explicit model.
+	payload := map[string]any{
 		"temperature":     0.1,
 		"max_tokens":      maxOutTokens,
 		"response_format": map[string]string{"type": "json_object"},
@@ -346,7 +345,11 @@ func callOpenAI(parent context.Context, to time.Duration, instructions, content 
 			{"role": "system", "content": instructions},
 			{"role": "user", "content": content},
 		},
-	})
+	}
+	if model := os.Getenv("AURSCAN_OPENAI_MODEL"); model != "" {
+		payload["model"] = model
+	}
+	body, _ := json.Marshal(payload)
 
 	dbgBlock("openai request body", string(body))
 	var lastErr error

--- a/internal/scan/llm_test.go
+++ b/internal/scan/llm_test.go
@@ -1,0 +1,67 @@
+package scan
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+)
+
+func startOpenAIStub(t *testing.T) (url string, bodyCh chan []byte) {
+	t.Helper()
+	bodyCh = make(chan []byte, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		bodyCh <- raw
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"{\"verdict\":\"OK\"}"}}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL, bodyCh
+}
+
+func requestModel(t *testing.T, raw []byte) (string, bool) {
+	t.Helper()
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal request body: %v\n%s", err, raw)
+	}
+	m, ok := got["model"]
+	if !ok {
+		return "", false
+	}
+	var s string
+	if err := json.Unmarshal(m, &s); err != nil {
+		t.Fatalf("unmarshal model field: %v", err)
+	}
+	return s, true
+}
+
+func TestCallOpenAIModelOmittedWhenEnvUnset(t *testing.T) {
+	os.Unsetenv("AURSCAN_OPENAI_MODEL")
+	url, bodyCh := startOpenAIStub(t)
+	t.Setenv("AURSCAN_OPENAI_URL", url)
+	if _, _, err := callOpenAI(context.Background(), time.Second, "sys", "user", 1); err != nil {
+		t.Fatalf("callOpenAI: %v", err)
+	}
+	if model, ok := requestModel(t, <-bodyCh); ok {
+		t.Fatalf("request sent model=%q; expected the field to be omitted", model)
+	}
+}
+
+func TestCallOpenAIModelForwardedWhenEnvSet(t *testing.T) {
+	const want = "z-ai/glm-5.1"
+	t.Setenv("AURSCAN_OPENAI_MODEL", want)
+	url, bodyCh := startOpenAIStub(t)
+	t.Setenv("AURSCAN_OPENAI_URL", url)
+	if _, _, err := callOpenAI(context.Background(), time.Second, "sys", "user", 1); err != nil {
+		t.Fatalf("callOpenAI: %v", err)
+	}
+	if model, ok := requestModel(t, <-bodyCh); !ok || model != want {
+		t.Fatalf("request model = %q ok=%v; want %q", model, ok, want)
+	}
+}


### PR DESCRIPTION
The OpenAI-compatible backend sent the placeholder "default-model" whenever AURSCAN_OPENAI_MODEL was unset, which breaks routing proxies (LiteLLM, vLLM, etc.) that select the model server-side and reject unknown model names.

Build the request payload without a "model" key, and add it only when AURSCAN_OPENAI_MODEL is non-empty. Sending "model": "" is avoided since some servers reject an empty string.

- internal/scan/llm.go: drop the default-model fallback; add model conditionally on AURSCAN_OPENAI_MODEL.
- internal/scan/llm_test.go: new httptest-backed tests asserting the key is omitted when unset and forwarded verbatim when set.
- README.md + CHANGELOG.md: document the new default and routing-proxy use case.

Fail-closed semantics, timeout handling, fallback-URL loop, and all other backends are unchanged.

Real-world use case. With this change I run aurscan against my own proxy fronting NVIDIA NIM (and other providers), so I can switch the underlying LLM on the fly without editing env vars or restarting aurscan.

Behavioral change to flag. This removes the hardcoded default-model placeholder that was sent when AURSCAN_OPENAI_MODEL was unset. In practice that placeholder was ignored by single-model servers (Ollama, llama.cpp, vLLM) and rejected by strict proxies — so the only users who could regress are on a server that both (a) requires the model field and (b) accepted the literal default-model. Those users should now set AURSCAN_OPENAI_MODEL explicitly. If that trade-off feels too intrusive, happy to revisit — e.g. keep the fallback only as a last resort.