### PR TITLE
fix: treat yay -Qua exit 1 as empty result, not an error (#2)

### DIFF
--- a/cmd/aurscan/helpers.go
+++ b/cmd/aurscan/helpers.go
@@ -10,5 +10,18 @@ func run(name string, args ...string) (string, error) {
 	return string(out), err
 }
 
+// runAllowExit1 runs a command and treats exit code 1 as success with empty
+// output. Used for commands like "yay -Qua" that exit 1 to signal "no results".
+func runAllowExit1(name string, args ...string) (string, error) {
+	out, err := exec.Command(name, args...).Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			return string(out), nil
+		}
+		return string(out), err
+	}
+	return string(out), nil
+}
+
 func splitLines(s string) []string { return strings.Split(s, "\n") }
 func fields(s string) []string     { return strings.Fields(s) }

--- a/cmd/aurscan/main.go
+++ b/cmd/aurscan/main.go
@@ -202,7 +202,7 @@ func main() {
 }
 
 func updateCheck() []scan.Result {
-	out, err := run("yay", "-Qua")
+	out, err := runAllowExit1("yay", "-Qua")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, ui.Red("error: ")+"yay -Qua failed: "+err.Error())
 		os.Exit(3)

--- a/cmd/aurscan/paclist.go
+++ b/cmd/aurscan/paclist.go
@@ -32,7 +32,7 @@ type paclistPackage struct {
 }
 
 func writePaclistFromYay() (int, error) {
-	out, err := run("yay", "-Qua")
+	out, err := runAllowExit1("yay", "-Qua")
 	if err != nil {
 		return 0, fmt.Errorf("yay -Qua failed: %w", err)
 	}


### PR DESCRIPTION
yay -Qua exits 1 when no AUR updates are pending (same convention as grep with no matches). --update-check and --gen-file were failing with an error in this normal case.