### PR TITLE
fix: make syay operation-aware so non-build yay ops pass through (#1)

### DIFF
--- a/internal/yay/yay.go
+++ b/internal/yay/yay.go
@@ -18,12 +18,15 @@ import (
 // aurscan-edit symlink is missing).
 const envForceEdit = "AURSCAN_EDIT_HOOK"
 
-// Wrapper is the `syay` entrypoint. It guarantees yay's editor-gate is pointed
-// at aurscan-edit, then hands off to the real yay via exec. Because yay invokes
-// the editor on every AUR PKGBUILD it is about to build — after download,
-// before build, regardless of how the package was chosen (bare `yay <term>`
-// search-install, `-S name`, or `-Syu`) and including AUR dependencies — this
-// is the one interception point that always sees the real, selected package.
+// Wrapper is the `syay` entrypoint. For build operations it points yay's
+// editor-gate at aurscan-edit, then hands off to the real yay via exec. Because
+// yay invokes the editor on every AUR PKGBUILD it is about to build — after
+// download, before build, regardless of how the package was chosen (bare
+// `yay <term>` search-install, `-S name`, or `-Syu`) and including AUR
+// dependencies — this is the one interception point that always sees the real,
+// selected package. Non-build operations (queries, searches, --version, --help,
+// removals) are passed straight through unmodified, so syay is a safe drop-in
+// for yay (`alias yay=syay`).
 func Wrapper(argv []string) {
 	yayPath, err := exec.LookPath("yay")
 	if err != nil {
@@ -35,20 +38,83 @@ func Wrapper(argv []string) {
 	}
 
 	env := os.Environ()
-	if userSetEditor(argv) {
-		// Respect an explicit --editor; chain to it after a clean scan instead.
-		fmt.Fprintln(os.Stderr, ui.Yellow(
-			"aurscan: --editor given on the command line; scanner will run first, "+
-				"then chain to your editor."))
-		argv = injectEditor(stripEditor(argv), self)
-	} else {
-		argv = injectEditor(argv, self)
+	// Only inject the PKGBUILD edit-gate for operations that actually build AUR
+	// packages. Forcing yay's edit flags onto queries/searches/version/help
+	// breaks them (e.g. `yay --version`, `yay -Ss foo`, `yay -Syu` with nothing
+	// to build), so everything else passes through untouched.
+	if buildsPackages(argv) {
+		if userSetEditor(argv) {
+			// Respect an explicit --editor; chain to it after a clean scan instead.
+			fmt.Fprintln(os.Stderr, ui.Yellow(
+				"aurscan: --editor given on the command line; scanner will run first, "+
+					"then chain to your editor."))
+			argv = injectEditor(stripEditor(argv), self)
+		} else {
+			argv = injectEditor(argv, self)
+		}
+		env = append(env, envForceEdit+"=1")
 	}
-	env = append(env, envForceEdit+"=1")
 
 	if err := syscall.Exec(yayPath, append([]string{yayPath}, argv...), env); err != nil {
 		die("exec yay failed: " + err.Error())
 	}
+}
+
+// buildsPackages reports whether a yay argv will actually fetch and build AUR
+// packages — the only case where the PKGBUILD edit-gate must fire.
+//
+// pacman/yay operations are the first uppercase letter after a single dash (or
+// a long --name): S sync, Q query, R remove, D database, F files, T deptest,
+// U upgrade-file, V version, G getpkgbuild, Y yay, P show, W web (plus -h/
+// --help). With no operation at all, yay defaults to a sync upgrade /
+// search-install, which builds. Within a sync (-S) operation the search/info/
+// list/groups/clean sub-modifiers (s/i/l/g/c) only read, they do not build.
+func buildsPackages(argv []string) bool {
+	hasOp := false     // an explicit operation flag was seen
+	isSync := false    // operation is -S / --sync
+	syncQuery := false // a non-building sync sub-modifier (search/info/list/groups/clean)
+
+loop:
+	for _, a := range argv {
+		switch {
+		case a == "--":
+			break loop // end of options; the rest are targets
+		case strings.HasPrefix(a, "--"):
+			name := strings.TrimPrefix(a, "--")
+			if i := strings.IndexByte(name, '='); i >= 0 {
+				name = name[:i]
+			}
+			switch name {
+			case "sync":
+				hasOp, isSync = true, true
+			case "query", "remove", "database", "files", "deptest",
+				"upgrade", "version", "help", "getpkgbuild", "yay", "show", "web":
+				hasOp = true
+			case "search", "info", "list", "groups", "clean":
+				syncQuery = true
+			}
+		case strings.HasPrefix(a, "-") && len(a) > 1:
+			letters := a[1:]
+			for i := 0; i < len(letters); i++ {
+				switch c := letters[i]; {
+				case c == 'h':
+					hasOp = true // -h help is a non-build operation (lowercase)
+				case c >= 'A' && c <= 'Z':
+					if !hasOp {
+						hasOp = true
+						isSync = c == 'S'
+					}
+				case c == 's' || c == 'i' || c == 'l' || c == 'g' || c == 'c':
+					syncQuery = true
+				}
+			}
+		}
+	}
+
+	if !hasOp {
+		return true // bare `yay` (-Syu) or `yay <term>` search-install → builds
+	}
+	return isSync && !syncQuery
 }
 
 func userSetEditor(argv []string) bool {

--- a/internal/yay/yay_test.go
+++ b/internal/yay/yay_test.go
@@ -6,6 +6,46 @@ import (
 	"testing"
 )
 
+func TestBuildsPackages(t *testing.T) {
+	tests := []struct {
+		name string
+		argv []string
+		want bool
+	}{
+		{"bare yay defaults to -Syu", nil, true},
+		{"search-install term", []string{"firefox"}, true},
+		{"sync install", []string{"-S", "firefox"}, true},
+		{"sync refresh+upgrade", []string{"-Syu"}, true},
+		{"sync upgrade only", []string{"-Su"}, true},
+		{"sync long", []string{"--sync", "firefox"}, true},
+		{"sync download-only builds", []string{"-Sw", "foo"}, true},
+		{"version short", []string{"-V"}, false},
+		{"version long", []string{"--version"}, false},
+		{"help short", []string{"-h"}, false},
+		{"help long", []string{"--help"}, false},
+		{"sync search", []string{"-Ss", "foo"}, false},
+		{"sync search long", []string{"--sync", "--search", "foo"}, false},
+		{"sync info", []string{"-Si", "foo"}, false},
+		{"sync list", []string{"-Sl"}, false},
+		{"sync clean", []string{"-Sc"}, false},
+		{"sync groups", []string{"-Sg"}, false},
+		{"query", []string{"-Q"}, false},
+		{"query explicit", []string{"-Qe"}, false},
+		{"query search", []string{"-Qs", "foo"}, false},
+		{"remove", []string{"-R", "foo"}, false},
+		{"files", []string{"-F", "foo"}, false},
+		{"getpkgbuild", []string{"-G", "foo"}, false},
+		{"upgrade from file", []string{"-U", "./foo.pkg.tar.zst"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildsPackages(tt.argv); got != tt.want {
+				t.Errorf("buildsPackages(%q) = %v, want %v", tt.argv, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestPackageRootFindsPKGBUILDParent(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "PKGBUILD"), []byte("pkgname=test\n"), 0o644); err != nil {


### PR DESCRIPTION
syay unconditionally appended yay's edit-gate flags (--editor/--editmenu/ --answeredit) to every invocation, so non-build operations broke: `yay --version`, `yay -Syu` with nothing to build, `-Ss` search, `-Q` queries, etc. all received install-only flags and errored.

Add buildsPackages(argv) to classify the yay operation and inject the gate only when yay will actually fetch and build an AUR package (bare `yay`, `yay <term>`, `-S <pkg>`, `-Syu`/`-Su`). Everything else execs the real yay untouched, making `alias yay=syay` a safe drop-in again.

Covered by a 24-case table-driven test; go vet + full suite pass.