### PR TITLE
feat(scan): backend fallback chain (issues #7, #35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,35 @@ Backends are auto-detected in this order. **The first one needs no API key at al
 5. **`AURSCAN_BACKEND=/path/to/cmd`** — any executable that reads the prompt on stdin and prints the reply on stdout.
 6. **No backend at all** — the static rules still run and still block on critical matches.
 
+### Backend fallback chain
+
+Those backends form a **chain**, not a single pick. aurscan tries them in the order above — a pinned `AURSCAN_BACKEND` stays first, otherwise every auto-detected backend is included — and when one fails (error, timeout, rate-limit, or unparseable output) it prints a one-line warning and tries the next. So a rate-limited Claude subscription transparently falls through to Codex or a local model ([#7](https://github.com/manticore-projects/aurscan/issues/7), [#35](https://github.com/manticore-projects/aurscan/issues/35)). Only when **every** backend fails does aurscan fall closed to `SUSPICIOUS` and block the build, exactly as before. On the success path only the first backend is ever called, so nothing changes for a single healthy backend.
+
+Extend the chain with priority-ordered config files `~/.config/aurscan/llm1.conf`, `llm2.conf`, … — tried in **numeric** order (`llm2` before `llm10`), after the environment-derived backends, then de-duplicated. Each file describes one backend as flat `key = value`:
+
+| key | meaning |
+|---|---|
+| `backend` | `claude` · `codex` · `api` · `openai` · or a `/path/to/exe` (a custom command, like `AURSCAN_BACKEND`) |
+| `model` | model id for `api` / `codex` / `openai` |
+| `url` | endpoint override (`openai` `/chat/completions`, or an Anthropic-compatible `/v1/messages` gateway for `api`) |
+| `fallback` | secondary `openai` URL (intra-backend, like `AURSCAN_OPENAI_URL_FALLBACK`) |
+| `api_key` | bearer / `x-api-key` for this backend |
+
+```ini
+# ~/.config/aurscan/llm1.conf — try the local GPU box first
+backend = openai
+url     = http://192.168.0.110:18080/v1/chat/completions
+model   = qwen2.5-coder-32b
+```
+```ini
+# ~/.config/aurscan/llm2.conf — then fall back to a custom command
+backend = /usr/local/bin/my-scanner
+```
+
+- **Values are literal:** don't quote them, and a `#`/`;` starts a comment only at the start of a line (not inline).
+- **Secrets:** prefer environment variables. If you put `api_key` in a file, `chmod 600` it — aurscan warns on startup when such a file is group- or other-readable.
+- **Latency:** each backend gets its own full `AURSCAN_TIMEOUT`, so a K-entry chain can take up to K × that budget if backends *stall* (an `openai` entry with a `fallback` URL counts as two); lower `AURSCAN_TIMEOUT` for long chains.
+
 <details>
 <summary>Local model setup (llama.cpp / Ollama / LiteLLM)</summary>
 
@@ -325,7 +354,7 @@ aurscan --rules-only <pkgname|./dir>     # or set AURSCAN_RULES_ONLY=1
 
 ## Safety model
 
-- **Fail-closed.** A backend error, timeout, fetch failure, or unparseable output becomes **SUSPICIOUS** and blocks the build. The scanner can fail, but it never fails *open*.
+- **Fail-closed.** A backend error, timeout, or unparseable output is first retried against the next backend in the chain; once every configured backend is exhausted — or on a fetch failure — the result becomes **SUSPICIOUS** and blocks the build. The scanner can fail, but it never fails *open*.
 - **Prompt-injection hardening.** Package files are sent as untrusted data, kept separate from the trusted instructions. The prompt treats embedded "this package is safe / ignore previous instructions" text as evidence of malice, and only the JSON contract is trusted when parsing. Both are covered by tests.
 - **No execution, no disk writes.** AUR snapshots are parsed in memory. Nothing from the suspect package is written to disk or run.
 - **Bounded context.** Binaries and files over 64 KB are skipped, and total context is capped at 240 KB.

--- a/cmd/aurscan/main.go
+++ b/cmd/aurscan/main.go
@@ -47,6 +47,7 @@ const usage = `usage:
 
 func main() {
 	scan.ExtraInstructions = config.ExtraInstructions()
+	scan.ExtraBackends = scan.BackendsFromConfig(config.LLMConfigs())
 	argv0 := os.Args[0]
 	args := os.Args[1:]
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,8 +4,13 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
 )
 
 // Dir returns aurscan's config directory, honoring AURSCAN_CONFIG_DIR, then
@@ -43,4 +48,110 @@ func ExtraInstructions() string {
 		}
 	}
 	return ""
+}
+
+// llmConfRe matches the priority-ordered backend config files
+// (~/.config/aurscan/llm1.conf, llm2.conf, …). The anchored capture group lets
+// us sort numerically (so llm2 precedes llm10) and rejects llm.conf, llmfoo.conf
+// and llm1.conf.bak.
+var llmConfRe = regexp.MustCompile(`^llm(\d+)\.conf$`)
+
+// llmConfKeys is the allowlist of recognised keys in an llmN.conf file. Anything
+// else is ignored, so future keys can be added without breaking older binaries.
+var llmConfKeys = map[string]bool{
+	"backend": true, "model": true, "url": true, "fallback": true, "api_key": true,
+}
+
+// LLMConfigs loads the priority-ordered backend config files under the config
+// directory and returns one key→value map per file, in numeric filename order
+// (llm1.conf, llm2.conf, …, llm10.conf). Each file describes ONE fallback
+// backend; the scan package turns these maps into a backend chain.
+//
+// The format is a flat, literal "key = value": comments (# or ; at the first
+// non-space character) and blank lines are skipped, the value runs verbatim to
+// end of line (no quote- or inline-comment stripping), and only the first '='
+// splits the line so '=' may appear in a value. An unreadable file is skipped
+// rather than fatal, and a missing config directory yields nil.
+func LLMConfigs() []map[string]string {
+	dir := Dir()
+	if dir == "" {
+		return nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+
+	type confFile struct {
+		n    int
+		name string
+	}
+	var files []confFile
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		m := llmConfRe.FindStringSubmatch(e.Name())
+		if m == nil {
+			continue
+		}
+		n, err := strconv.Atoi(m[1])
+		if err != nil {
+			continue
+		}
+		files = append(files, confFile{n: n, name: e.Name()})
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].n < files[j].n })
+
+	var out []map[string]string
+	for _, f := range files {
+		path := filepath.Join(dir, f.name)
+		b, err := os.ReadFile(path)
+		if err != nil {
+			continue // skip a single unreadable file, do not abort
+		}
+		m := parseLLMConf(string(b))
+		if len(m) == 0 {
+			continue
+		}
+		if m["api_key"] != "" {
+			warnIfSecretReadable(path)
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+func parseLLMConf(body string) map[string]string {
+	m := map[string]string{}
+	for i, line := range strings.Split(body, "\n") {
+		if i == 0 {
+			line = strings.TrimPrefix(line, "\ufeff") // strip a leading UTF-8 BOM (TrimSpace won't)
+		}
+		line = strings.TrimSpace(line) // also drops a trailing \r from CRLF
+		if line == "" || line[0] == '#' || line[0] == ';' {
+			continue
+		}
+		k, v, ok := strings.Cut(line, "=") // split on the FIRST '=' only
+		if !ok {
+			continue
+		}
+		key := strings.ToLower(strings.TrimSpace(k))
+		val := strings.TrimSpace(v)
+		if !llmConfKeys[key] || val == "" {
+			continue
+		}
+		m[key] = val // last assignment of a key within a file wins
+	}
+	return m
+}
+
+// warnIfSecretReadable warns when an llmN.conf holding an api_key is readable by
+// group or other, since secrets are better kept in environment variables.
+func warnIfSecretReadable(path string) {
+	if info, err := os.Stat(path); err == nil && info.Mode().Perm()&0o077 != 0 {
+		fmt.Fprintf(os.Stderr,
+			"WARNING: %s is group/other-readable and contains api_key; run 'chmod 600 %s' "+
+				"(env vars are the recommended place for secrets)\n", path, path)
+	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,171 @@
+package config
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeConf writes a file into the (temp) config dir for a test.
+func writeConf(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return p
+}
+
+// captureStderr runs fn with os.Stderr redirected and returns what was written.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+	done := make(chan string, 1)
+	go func() {
+		var b bytes.Buffer
+		_, _ = io.Copy(&b, r)
+		done <- b.String()
+	}()
+	fn()
+	_ = w.Close()
+	os.Stderr = old
+	return <-done
+}
+
+func TestLLMConfigsNumericOrder(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("AURSCAN_CONFIG_DIR", dir)
+	writeConf(t, dir, "llm10.conf", "backend = openai\nurl = http://ten")
+	writeConf(t, dir, "llm2.conf", "backend = codex")
+	writeConf(t, dir, "llm1.conf", "backend = claude")
+
+	got := LLMConfigs()
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3 (%v)", len(got), got)
+	}
+	want := []string{"claude", "codex", "openai"} // 1, 2, 10 — numeric, not lexical
+	for i, w := range want {
+		if got[i]["backend"] != w {
+			t.Fatalf("entry %d backend = %q, want %q (order: %v)", i, got[i]["backend"], w, got)
+		}
+	}
+	if got[2]["url"] != "http://ten" {
+		t.Fatalf("llm10 url = %q", got[2]["url"])
+	}
+}
+
+func TestLLMConfigsParsingEdgeCases(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("AURSCAN_CONFIG_DIR", dir)
+	// BOM on the first line; comments; blank line; CRLF; '=' in value; quoted
+	// literal; inline '#' kept verbatim; duplicate key (last wins); empty value.
+	body := "\ufeffbackend = openai\r\n" +
+		"# a comment\n" +
+		"; another comment\n" +
+		"\n" +
+		"url = http://x # primary\r\n" +
+		"api_key = sk-a=b\n" +
+		"model = \"q-1\"\n" +
+		"model = q-2\n" +
+		"fallback =\n"
+	writeConf(t, dir, "llm1.conf", body)
+
+	got := LLMConfigs()
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	m := got[0]
+	checks := map[string]string{
+		"backend": "openai",
+		"url":     "http://x # primary", // inline comment NOT stripped
+		"api_key": "sk-a=b",             // only the first '=' splits
+		"model":   "q-2",                // duplicate: last wins; quotes are literal on the first, overwritten
+	}
+	for k, want := range checks {
+		if m[k] != want {
+			t.Fatalf("key %q = %q, want %q", k, m[k], want)
+		}
+	}
+	if _, ok := m["fallback"]; ok {
+		t.Fatalf("empty value should not be stored, got fallback=%q", m["fallback"])
+	}
+}
+
+func TestLLMConfigsQuotedValueLiteral(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("AURSCAN_CONFIG_DIR", dir)
+	writeConf(t, dir, "llm1.conf", "backend = openai\napi_key = \"sk-1\"")
+	m := LLMConfigs()[0]
+	if m["api_key"] != "\"sk-1\"" {
+		t.Fatalf("api_key = %q, want the quotes preserved verbatim", m["api_key"])
+	}
+}
+
+func TestLLMConfigsMissingDir(t *testing.T) {
+	t.Setenv("AURSCAN_CONFIG_DIR", filepath.Join(t.TempDir(), "does-not-exist"))
+	if got := LLMConfigs(); got != nil {
+		t.Fatalf("want nil for missing dir, got %v", got)
+	}
+}
+
+func TestLLMConfigsSkipsUnreadableFile(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: mode 0000 is still readable")
+	}
+	dir := t.TempDir()
+	t.Setenv("AURSCAN_CONFIG_DIR", dir)
+	bad := writeConf(t, dir, "llm1.conf", "backend = openai")
+	if err := os.Chmod(bad, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(bad, 0o600) })
+	writeConf(t, dir, "llm2.conf", "backend = codex")
+
+	got := LLMConfigs()
+	if len(got) != 1 || got[0]["backend"] != "codex" {
+		t.Fatalf("want exactly the readable codex entry, got %v", got)
+	}
+}
+
+func TestLLMConfigsAPIKeyPermissionWarning(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("AURSCAN_CONFIG_DIR", dir)
+	p := writeConf(t, dir, "llm1.conf", "backend = openai\napi_key = sk-test")
+	if err := os.Chmod(p, 0o644); err != nil { // group/other-readable
+		t.Fatalf("chmod: %v", err)
+	}
+	out := captureStderr(t, func() { LLMConfigs() })
+	if !strings.Contains(out, "chmod 600") || !strings.Contains(out, "api_key") {
+		t.Fatalf("expected a chmod-600 warning, got %q", out)
+	}
+
+	// 0600 → no warning.
+	if err := os.Chmod(p, 0o600); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	out = captureStderr(t, func() { LLMConfigs() })
+	if strings.Contains(out, "chmod 600") {
+		t.Fatalf("did not expect a warning for a 0600 file, got %q", out)
+	}
+}
+
+func TestLLMConfigsNoSecretNoWarning(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("AURSCAN_CONFIG_DIR", dir)
+	p := writeConf(t, dir, "llm1.conf", "backend = openai\nurl = http://x")
+	if err := os.Chmod(p, 0o644); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	out := captureStderr(t, func() { LLMConfigs() })
+	if strings.Contains(out, "chmod 600") {
+		t.Fatalf("a file without api_key must never warn, got %q", out)
+	}
+}

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/manticore-projects/aurscan/internal/scan"
@@ -23,5 +24,29 @@ package() { make DESTDIR="$pkgdir" install; }`}
 	r := RunRulesOnly("hello", files)
 	if r.V.Verdict != "OK" {
 		t.Fatalf("verdict = %q, want OK", r.V.Verdict)
+	}
+}
+
+// TestRunNoBackendNote pins down the unchanged State A: with no backend
+// configured at all (no env backend, no llmN.conf), Run returns the static-rules
+// verdict carrying the original "no LLM backend configured" note — NOT the
+// chain-exhaustion path.
+func TestRunNoBackendNote(t *testing.T) {
+	t.Setenv("PATH", t.TempDir()) // no claude/codex
+	t.Setenv("AURSCAN_BACKEND", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("AURSCAN_OPENAI_URL", "")
+	t.Setenv("AURSCAN_RULES_ONLY", "")
+	t.Setenv("AURSCAN_CONFIG_DIR", t.TempDir()) // empty: no llmN.conf
+	scan.ExtraBackends = nil
+	t.Cleanup(func() { scan.ExtraBackends = nil })
+
+	files := scan.Files{"PKGBUILD": `build() { make; }`}
+	r := Run("hello", files, "")
+	if r.V.Verdict != "OK" {
+		t.Fatalf("verdict = %q, want OK", r.V.Verdict)
+	}
+	if !strings.Contains(r.V.Summary, "no LLM backend configured") {
+		t.Fatalf("summary = %q, want the 'no LLM backend configured' note", r.V.Summary)
 	}
 }

--- a/internal/scan/chain_test.go
+++ b/internal/scan/chain_test.go
@@ -1,0 +1,317 @@
+package scan
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// setExtraBackends installs config-derived backends for one test and clears them
+// afterwards, so no test leaks chain state into another.
+func setExtraBackends(t *testing.T, be ...Backend) {
+	t.Helper()
+	t.Cleanup(func() { ExtraBackends = nil })
+	ExtraBackends = be
+}
+
+// startStub serves a fixed OpenAI-style response and counts the requests it sees.
+func startStub(t *testing.T, status int, body string) (url string, hits *int32) {
+	t.Helper()
+	var c int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&c, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL, &c
+}
+
+// openAIEnvelope wraps a model "content" string in a valid /chat/completions body.
+func openAIEnvelope(content string) string {
+	b, _ := json.Marshal(map[string]any{
+		"choices": []map[string]any{{"message": map[string]string{"content": content}}},
+		"usage":   map[string]int{"prompt_tokens": 1, "completion_tokens": 1},
+	})
+	return string(b)
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+	done := make(chan string, 1)
+	go func() {
+		var b bytes.Buffer
+		_, _ = io.Copy(&b, r)
+		done <- b.String()
+	}()
+	fn()
+	_ = w.Close()
+	os.Stderr = old
+	return <-done
+}
+
+// isolateEnv clears every env signal envBackends() looks at, so a test starts
+// from an empty environment chain and controls it explicitly.
+func isolateEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("PATH", t.TempDir()) // no claude/codex on PATH
+	t.Setenv("AURSCAN_BACKEND", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("AURSCAN_OPENAI_URL", "")
+	t.Setenv("AURSCAN_OPENAI_URL_FALLBACK", "")
+	t.Setenv("AURSCAN_OPENAI_MODEL", "")
+	t.Setenv("AURSCAN_RULES_ONLY", "")
+}
+
+var testFiles = Files{"PKGBUILD": "pkgname=x"}
+
+func TestBackendsFromConfig(t *testing.T) {
+	got := BackendsFromConfig([]map[string]string{
+		{"backend": "openai", "url": "http://x", "model": "m", "api_key": "k"},
+		{"backend": "/usr/local/bin/scan"}, // a path => custom command (mirrors AURSCAN_BACKEND=/path)
+		{"backend": "claude"},
+		{"model": "no-backend"}, // skipped: no backend=
+	})
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3 (%v)", len(got), got)
+	}
+	if got[0] != (Backend{Kind: "openai", URL: "http://x", Model: "m", APIKey: "k"}) {
+		t.Fatalf("entry0 = %v", got[0])
+	}
+	if got[1] != (Backend{Kind: "cmd", Cmd: "/usr/local/bin/scan"}) {
+		t.Fatalf("entry1 = %v", got[1])
+	}
+	if got[2].Kind != "claude" {
+		t.Fatalf("entry2 = %v", got[2])
+	}
+}
+
+func TestDedupe(t *testing.T) {
+	in := []Backend{
+		{Kind: "claude"}, {Kind: "claude"},
+		{Kind: "openai", URL: "a"}, {Kind: "openai", URL: "b"},
+	}
+	got := dedupe(in)
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3 (%v)", len(got), got)
+	}
+}
+
+func TestDedupeEnvVsConfigSameEndpointNotCollapsed(t *testing.T) {
+	isolateEnv(t)
+	t.Setenv("AURSCAN_OPENAI_URL", "http://x")
+	setExtraBackends(t, Backend{Kind: "openai", URL: "http://x"})
+	got := Backends()
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2 (env {openai,URL:\"\"} + config {openai,URL:http://x}); got %v", len(got), got)
+	}
+	if got[0].URL != "" || got[1].URL != "http://x" {
+		t.Fatalf("order/fields wrong: %v", got)
+	}
+}
+
+func TestChainFallthroughTransportError(t *testing.T) {
+	bad, _ := startStub(t, 500, "")
+	good, _ := startStub(t, 200, openAIEnvelope(`{"verdict":"OK"}`))
+	t.Setenv("AURSCAN_BACKEND", "openai")
+	t.Setenv("AURSCAN_OPENAI_URL", bad)
+	t.Setenv("AURSCAN_OPENAI_MODEL", "")
+	setExtraBackends(t, Backend{Kind: "openai", URL: good})
+
+	res := Scan("pkg", testFiles, Signals{})
+	if res.V.Verdict != "OK" || res.Failed {
+		t.Fatalf("verdict=%q failed=%v, want OK/false", res.V.Verdict, res.Failed)
+	}
+}
+
+func TestChainParseFallthrough(t *testing.T) {
+	// First backend responds 200 but its content is not verdict JSON.
+	bad, _ := startStub(t, 200, openAIEnvelope("hello, not json"))
+	good, _ := startStub(t, 200, openAIEnvelope(`{"verdict":"OK"}`))
+	t.Setenv("AURSCAN_BACKEND", "openai")
+	t.Setenv("AURSCAN_OPENAI_URL", bad)
+	t.Setenv("AURSCAN_OPENAI_MODEL", "")
+	setExtraBackends(t, Backend{Kind: "openai", URL: good})
+
+	res := Scan("pkg", testFiles, Signals{})
+	if res.V.Verdict != "OK" || res.Failed {
+		t.Fatalf("verdict=%q failed=%v, want OK/false (parse fall-through)", res.V.Verdict, res.Failed)
+	}
+}
+
+func TestChainUnknownVerdictFallthrough(t *testing.T) {
+	bad, _ := startStub(t, 200, openAIEnvelope(`{"verdict":"maybe"}`))
+	good, _ := startStub(t, 200, openAIEnvelope(`{"verdict":"OK"}`))
+	t.Setenv("AURSCAN_BACKEND", "openai")
+	t.Setenv("AURSCAN_OPENAI_URL", bad)
+	t.Setenv("AURSCAN_OPENAI_MODEL", "")
+	setExtraBackends(t, Backend{Kind: "openai", URL: good})
+
+	res := Scan("pkg", testFiles, Signals{})
+	if res.V.Verdict != "OK" || res.Failed {
+		t.Fatalf("verdict=%q failed=%v, want OK/false (unknown-verdict fall-through, NOT a stop at SUSPICIOUS)", res.V.Verdict, res.Failed)
+	}
+}
+
+func TestGenuineConfidenceZeroStopsChain(t *testing.T) {
+	// confidence omitted (=> 0) and summary literally contains "fail-closed";
+	// this is still a GENUINE MALICIOUS verdict and must stop the chain.
+	first, _ := startStub(t, 200, openAIEnvelope(`{"verdict":"MALICIOUS","summary":"prefer a fail-closed posture"}`))
+	second, secondHits := startStub(t, 200, openAIEnvelope(`{"verdict":"OK"}`))
+	t.Setenv("AURSCAN_BACKEND", "openai")
+	t.Setenv("AURSCAN_OPENAI_URL", first)
+	t.Setenv("AURSCAN_OPENAI_MODEL", "")
+	setExtraBackends(t, Backend{Kind: "openai", URL: second})
+
+	res := Scan("pkg", testFiles, Signals{})
+	if res.V.Verdict != "MALICIOUS" || res.Failed {
+		t.Fatalf("verdict=%q failed=%v, want MALICIOUS/false", res.V.Verdict, res.Failed)
+	}
+	if n := atomic.LoadInt32(secondHits); n != 0 {
+		t.Fatalf("second backend was called %d time(s); a genuine verdict must stop the chain", n)
+	}
+}
+
+func TestCmdFallthrough(t *testing.T) {
+	dir := t.TempDir()
+	fail := filepath.Join(dir, "fail.sh")
+	ok := filepath.Join(dir, "ok.sh")
+	if err := os.WriteFile(fail, []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(ok, []byte("#!/bin/sh\nprintf '{\"verdict\":\"OK\"}'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AURSCAN_BACKEND", fail) // pinned path => {Kind:"cmd", Cmd:fail}
+	setExtraBackends(t, Backend{Kind: "cmd", Cmd: ok})
+
+	var res Result
+	out := captureStderr(t, func() { res = Scan("pkg", testFiles, Signals{}) })
+	if res.V.Verdict != "OK" || res.Failed {
+		t.Fatalf("verdict=%q failed=%v, want OK/false", res.V.Verdict, res.Failed)
+	}
+	if !strings.Contains(out, "WARNING: backend cmd "+fail+" failed; trying next") {
+		t.Fatalf("expected a cmd-labelled warning, got %q", out)
+	}
+}
+
+func TestAutoDetectClaudeCodexFallthrough(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "claude"), []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "codex"), []byte("#!/bin/sh\nprintf '{\"verdict\":\"OK\",\"confidence\":80}\\n'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// PATH = our dir only, so envBackends() auto-detects exactly [claude, codex].
+	t.Setenv("PATH", dir)
+	t.Setenv("AURSCAN_BACKEND", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("AURSCAN_OPENAI_URL", "")
+	t.Setenv("AURSCAN_RULES_ONLY", "")
+	setExtraBackends(t) // none
+
+	var res Result
+	_ = captureStderr(t, func() { res = Scan("pkg", testFiles, Signals{}) })
+	if res.V.Verdict != "OK" || res.Failed {
+		t.Fatalf("verdict=%q failed=%v, want OK/false (claude→codex auto fallback)", res.V.Verdict, res.Failed)
+	}
+}
+
+func TestCallOpenAIPrefersSpecURLOverEnv(t *testing.T) {
+	env500, _ := startStub(t, 500, "")
+	spec, n := startStub(t, 200, openAIEnvelope(`{"verdict":"OK"}`))
+	t.Setenv("AURSCAN_OPENAI_URL", env500)
+	text, _, err := callOpenAI(context.Background(), time.Second, Backend{Kind: "openai", URL: spec}, "sys", "user", 1)
+	if err != nil {
+		t.Fatalf("callOpenAI: %v", err)
+	}
+	if !strings.Contains(text, `"verdict":"OK"`) {
+		t.Fatalf("content = %q, want the spec-URL response", text)
+	}
+	if got := atomic.LoadInt32(n); got != 1 {
+		t.Fatalf("spec URL called %d time(s), want 1", got)
+	}
+}
+
+func TestEnvBackendsLeaveModelEmpty(t *testing.T) {
+	isolateEnv(t)
+	t.Setenv("ANTHROPIC_API_KEY", "key")
+	t.Setenv("AURSCAN_OPENAI_URL", "http://x")
+	t.Setenv("AURSCAN_MODEL", "api-x")
+	t.Setenv("AURSCAN_CODEX_MODEL", "codex-x")
+	t.Setenv("AURSCAN_OPENAI_MODEL", "oai-x")
+
+	got := envBackends()
+	if len(got) == 0 {
+		t.Fatal("expected at least the api and openai env backends")
+	}
+	for _, be := range got {
+		if be.Model != "" || be.URL != "" || be.APIKey != "" || be.Fallback != "" {
+			t.Fatalf("env backend %v has non-empty settings; must stay empty so callX reads env", be)
+		}
+	}
+}
+
+func TestSecretNeverLeaksToStderr(t *testing.T) {
+	Debug = true
+	t.Cleanup(func() { Debug = false })
+	isolateEnv(t)
+	stub, _ := startStub(t, 200, openAIEnvelope(`{"verdict":"OK"}`))
+	setExtraBackends(t, Backend{Kind: "openai", URL: stub, APIKey: "SENTINEL_SECRET_KEY"})
+
+	out := captureStderr(t, func() { Scan("pkg", testFiles, Signals{}) })
+	if strings.Contains(out, "SENTINEL_SECRET_KEY") {
+		t.Fatalf("api key leaked to stderr:\n%s", out)
+	}
+	if !strings.Contains(out, "hasKey:yes") {
+		t.Fatalf("expected redacted Backend.String() in chain debug line, got:\n%s", out)
+	}
+}
+
+func TestChainExhausted(t *testing.T) {
+	a, _ := startStub(t, 500, "")
+	b, _ := startStub(t, 500, "")
+	t.Setenv("AURSCAN_BACKEND", "openai")
+	t.Setenv("AURSCAN_OPENAI_URL", a)
+	t.Setenv("AURSCAN_OPENAI_MODEL", "")
+	setExtraBackends(t, Backend{Kind: "openai", URL: b})
+
+	res := Scan("pkg", testFiles, Signals{})
+	if !res.Failed || res.V.Verdict != "SUSPICIOUS" {
+		t.Fatalf("verdict=%q failed=%v, want SUSPICIOUS/true (chain exhausted, fail-closed)", res.V.Verdict, res.Failed)
+	}
+}
+
+func TestSingleBackendFailureSilentOnStderr(t *testing.T) {
+	isolateEnv(t)
+	bad, _ := startStub(t, 500, "")
+	t.Setenv("AURSCAN_BACKEND", "openai")
+	t.Setenv("AURSCAN_OPENAI_URL", bad)
+	setExtraBackends(t) // single-backend chain: no "next"
+
+	var res Result
+	out := captureStderr(t, func() { res = Scan("pkg", testFiles, Signals{}) })
+	if !res.Failed || res.V.Verdict != "SUSPICIOUS" {
+		t.Fatalf("verdict=%q failed=%v, want SUSPICIOUS/true", res.V.Verdict, res.Failed)
+	}
+	if strings.Contains(out, "WARNING:") {
+		t.Fatalf("a lone backend failing must not print a 'trying next' warning, got %q", out)
+	}
+}

--- a/internal/scan/llm.go
+++ b/internal/scan/llm.go
@@ -43,37 +43,141 @@ func DefaultModel() string {
 	return "claude-sonnet-4-6"
 }
 
-// Backend describes the resolved LLM backend.
+// Backend describes one resolved LLM backend in the fallback chain.
+//
+// Backend MUST stay all-comparable (every field a string) because dedupe keys a
+// map[Backend]bool on it. NEVER print a Backend or []Backend with %v/%+v — use
+// String(), which redacts APIKey so a stray debug line cannot leak a secret.
+//
+// Empty setting fields mean "use the legacy environment lookup". Env-derived
+// specs keep them empty so each callX reads its own env var at call time; only
+// llmN.conf-derived specs populate them.
 type Backend struct {
-	Kind string // "claude", "codex", "api", "openai", or "cmd"
-	Cmd  string // executable path when Kind == "cmd"
+	Kind     string // "claude", "codex", "api", "openai", or "cmd"
+	Cmd      string // executable path when Kind == "cmd"
+	Model    string // AURSCAN_MODEL / AURSCAN_CODEX_MODEL / AURSCAN_OPENAI_MODEL (per kind)
+	URL      string // openai /chat/completions URL (or an Anthropic-compatible /v1/messages gateway for "api")
+	Fallback string // openai secondary URL (intra-backend, like AURSCAN_OPENAI_URL_FALLBACK)
+	APIKey   string // ANTHROPIC_API_KEY / AURSCAN_OPENAI_API_KEY
 }
 
-// PickBackend auto-detects an available backend, honoring AURSCAN_BACKEND.
-// Recognised values: "claude", "codex", "api", "openai" (OpenAI-compatible
-// local server such as llama.cpp/Ollama/vLLM), or a path to a custom executable.
-func PickBackend() (Backend, error) {
+// String renders a Backend for debug output with the secret redacted.
+func (b Backend) String() string {
+	key := "no"
+	if b.APIKey != "" {
+		key = "yes"
+	}
+	return fmt.Sprintf("{kind:%s cmd:%q model:%q url:%q fallback:%q hasKey:%s}",
+		b.Kind, b.Cmd, b.Model, b.URL, b.Fallback, key)
+}
+
+// ExtraBackends holds the fallback backends parsed from ~/.config/aurscan/llmN.conf.
+// It is set once at startup by the CLI (mirroring ExtraInstructions) and appended
+// after the environment-derived backends to form the chain. Empty by default, so
+// with no config files the chain is exactly the auto-detected/pinned env backend.
+var ExtraBackends []Backend
+
+// nz returns a if non-empty, else b — used to let a per-backend spec field
+// override the legacy environment lookup while keeping the env path intact.
+func nz(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}
+
+// backendLabel is the short name used in the "trying next" warning. Distinct
+// cmd backends are disambiguated by their path.
+func backendLabel(be Backend) string {
+	if be.Kind == "cmd" && be.Cmd != "" {
+		return "cmd " + be.Cmd
+	}
+	return be.Kind
+}
+
+// BackendsFromConfig turns parsed llmN.conf maps into backend specs. The
+// "backend" value mirrors AURSCAN_BACKEND: one of claude/codex/api/openai, or
+// any other value (e.g. a /path/to/exe) treated as a custom command.
+func BackendsFromConfig(maps []map[string]string) []Backend {
+	var out []Backend
+	for _, m := range maps {
+		var be Backend
+		switch b := m["backend"]; {
+		case b == "claude" || b == "codex" || b == "api" || b == "openai":
+			be = Backend{Kind: b}
+		case b != "": // a path or any other value => custom command (mirrors AURSCAN_BACKEND=/path)
+			be = Backend{Kind: "cmd", Cmd: b}
+		default:
+			dbg("config: skipping llmN.conf entry with no backend= value")
+			continue
+		}
+		be.Model, be.URL, be.Fallback, be.APIKey = m["model"], m["url"], m["fallback"], m["api_key"]
+		out = append(out, be)
+	}
+	return out
+}
+
+// envBackends resolves the backend(s) from the environment, honoring
+// AURSCAN_BACKEND. A pinned value yields exactly one backend (recognised kind,
+// or any other value as a custom executable path). Unpinned, it auto-detects
+// ALL available backends in the documented preference order — so a failure of
+// the first (e.g. Claude) falls through to the next (e.g. Codex). On the success
+// path only the first is ever invoked, so standard operation is unchanged.
+func envBackends() []Backend {
 	switch b := os.Getenv("AURSCAN_BACKEND"); {
 	case b == "claude" || b == "codex" || b == "api" || b == "openai":
-		return Backend{Kind: b}, nil
+		return []Backend{{Kind: b}}
 	case b != "":
-		return Backend{Kind: "cmd", Cmd: b}, nil
+		return []Backend{{Kind: "cmd", Cmd: b}}
 	}
+	var out []Backend
 	if _, err := exec.LookPath("claude"); err == nil {
-		return Backend{Kind: "claude"}, nil
+		out = append(out, Backend{Kind: "claude"})
 	}
 	if _, err := exec.LookPath("codex"); err == nil {
-		return Backend{Kind: "codex"}, nil
+		out = append(out, Backend{Kind: "codex"})
 	}
 	if os.Getenv("ANTHROPIC_API_KEY") != "" {
-		return Backend{Kind: "api"}, nil
+		out = append(out, Backend{Kind: "api"})
 	}
 	if os.Getenv("AURSCAN_OPENAI_URL") != "" {
-		return Backend{Kind: "openai"}, nil
+		out = append(out, Backend{Kind: "openai"})
 	}
-	return Backend{}, fmt.Errorf("no backend: install Claude Code (`claude`) or Codex CLI (`codex`) and log in, " +
-		"set ANTHROPIC_API_KEY, set AURSCAN_OPENAI_URL for a local model, " +
-		"or AURSCAN_BACKEND=/path/to/cmd")
+	return out
+}
+
+// Backends is the ordered fallback chain: environment-derived backends first,
+// then the llmN.conf-derived ExtraBackends, deduplicated (first occurrence wins).
+func Backends() []Backend {
+	return dedupe(append(envBackends(), ExtraBackends...))
+}
+
+// dedupe drops exact duplicate specs while preserving order. Equality is full
+// struct equality, so two backends differing only in URL/model remain distinct.
+func dedupe(in []Backend) []Backend {
+	seen := map[Backend]bool{}
+	var out []Backend
+	for _, be := range in {
+		if seen[be] {
+			continue
+		}
+		seen[be] = true
+		out = append(out, be)
+	}
+	return out
+}
+
+// PickBackend returns the first backend in the chain, or an error if the chain
+// is empty. It is the gate pipeline.Run uses to decide LLM-vs-rules; Scan walks
+// the full chain itself.
+func PickBackend() (Backend, error) {
+	bs := Backends()
+	if len(bs) == 0 {
+		return Backend{}, fmt.Errorf("no backend: install Claude Code (`claude`) or Codex CLI (`codex`) and log in, " +
+			"set ANTHROPIC_API_KEY, set AURSCAN_OPENAI_URL for a local model, " +
+			"or AURSCAN_BACKEND=/path/to/cmd")
+	}
+	return bs[0], nil
 }
 
 func estimateTokens(s string) int { return len(s) / 4 }
@@ -98,6 +202,13 @@ func Call(instructions, content string) (string, Usage, error) {
 	if err != nil {
 		return "", Usage{}, err
 	}
+	return CallBackend(be, instructions, content)
+}
+
+// CallBackend sends instructions + content to a specific backend and returns
+// the raw model text plus usage. Scan calls this once per backend as it walks
+// the fallback chain. Each backend gets its own full llmTimeout budget.
+func CallBackend(be Backend, instructions, content string) (string, Usage, error) {
 	dbg("backend=%s cmd=%q", be.Kind, be.Cmd)
 	to := llmTimeout()
 	estIn := estimateTokens(instructions + content)
@@ -105,26 +216,25 @@ func Call(instructions, content string) (string, Usage, error) {
 	var (
 		text string
 		u    Usage
+		err  error
 	)
 	switch be.Kind {
 	case "openai":
 		// Per-attempt deadlines live inside callOpenAI so that a stalled
 		// primary URL does not eat the fallback URL's whole budget.
-		text, u, err = callOpenAI(context.Background(), to, instructions, content, estIn)
+		text, u, err = callOpenAI(context.Background(), to, be, instructions, content, estIn)
 	default:
-		var ctx context.Context
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(context.Background(), to)
+		ctx, cancel := context.WithTimeout(context.Background(), to)
 		defer cancel()
 		switch be.Kind {
 		case "claude":
-			text, u, err = callClaudeCLI(ctx, instructions, content, estIn)
+			text, u, err = callClaudeCLI(ctx, be, instructions, content, estIn)
 		case "codex":
-			text, u, err = callCodexCLI(ctx, instructions, content, estIn)
+			text, u, err = callCodexCLI(ctx, be, instructions, content, estIn)
 		case "api":
-			text, u, err = callAPI(ctx, instructions, content)
+			text, u, err = callAPI(ctx, be, instructions, content)
 		default:
-			text, u, err = callCmd(ctx, be.Cmd, instructions, content, estIn)
+			text, u, err = callCmd(ctx, be, instructions, content, estIn)
 		}
 	}
 	if err != nil {
@@ -146,7 +256,8 @@ func annotateTimeout(err error, to time.Duration) error {
 	return err
 }
 
-func callClaudeCLI(ctx context.Context, instructions, content string, estIn int) (string, Usage, error) {
+func callClaudeCLI(ctx context.Context, be Backend, instructions, content string, estIn int) (string, Usage, error) {
+	_ = be // the Claude Code CLI takes no model flag today; be.Model/APIKey are a future hook
 	run := func(args ...string) (string, error) {
 		dbg("claude CLI args=%v", args)
 		dbgBlock("claude stdin (untrusted package content)", content)
@@ -247,7 +358,7 @@ func parseClaudeEnvelope(raw string, estIn int) (string, Usage, bool) {
 	return "", Usage{}, false
 }
 
-func callCodexCLI(ctx context.Context, instructions, content string, estIn int) (string, Usage, error) {
+func callCodexCLI(ctx context.Context, be Backend, instructions, content string, estIn int) (string, Usage, error) {
 	args := []string{
 		"exec",
 		"--skip-git-repo-check",
@@ -256,7 +367,7 @@ func callCodexCLI(ctx context.Context, instructions, content string, estIn int) 
 		"--sandbox", "read-only",
 		"--color", "never",
 	}
-	if model := os.Getenv("AURSCAN_CODEX_MODEL"); model != "" {
+	if model := nz(be.Model, os.Getenv("AURSCAN_CODEX_MODEL")); model != "" {
 		args = append(args, "--model", model)
 	}
 	args = append(args, instructions)
@@ -272,8 +383,8 @@ func callCodexCLI(ctx context.Context, instructions, content string, estIn int) 
 	return text, Usage{In: estIn, Out: estimateTokens(text), Estimated: true}, nil
 }
 
-func callAPI(ctx context.Context, instructions, content string) (string, Usage, error) {
-	model := DefaultModel()
+func callAPI(ctx context.Context, be Backend, instructions, content string) (string, Usage, error) {
+	model := nz(be.Model, DefaultModel())
 	body, _ := json.Marshal(map[string]any{
 		"model":      model,
 		"max_tokens": maxOutTokens,
@@ -281,9 +392,9 @@ func callAPI(ctx context.Context, instructions, content string) (string, Usage, 
 		"messages":   []map[string]string{{"role": "user", "content": content}},
 	})
 	dbgBlock("anthropic API request body", string(body))
-	req, _ := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(body))
+	req, _ := http.NewRequestWithContext(ctx, "POST", nz(be.URL, apiURL), bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("x-api-key", os.Getenv("ANTHROPIC_API_KEY"))
+	req.Header.Set("x-api-key", nz(be.APIKey, os.Getenv("ANTHROPIC_API_KEY")))
 	req.Header.Set("anthropic-version", "2023-06-01")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -327,12 +438,23 @@ func callAPI(ctx context.Context, instructions, content string) (string, Usage, 
 // local CPU instance — generalising the community connector from issue #1.
 // Each URL gets its own full timeout budget. Tokens are taken from the server's
 // usage block when present, else estimated; cost is n/a for local models.
-func callOpenAI(parent context.Context, to time.Duration, instructions, content string, estIn int) (string, Usage, error) {
-	urls := []string{os.Getenv("AURSCAN_OPENAI_URL")}
-	if fb := os.Getenv("AURSCAN_OPENAI_URL_FALLBACK"); fb != "" {
-		urls = append(urls, fb)
+func callOpenAI(parent context.Context, to time.Duration, be Backend, instructions, content string, estIn int) (string, Usage, error) {
+	// A spec URL fully overrides the environment; the env primary/fallback pair
+	// is used only when the spec leaves URL empty (the env-derived backend).
+	var urls []string
+	if be.URL != "" {
+		urls = append(urls, be.URL)
+	} else if u := os.Getenv("AURSCAN_OPENAI_URL"); u != "" {
+		urls = append(urls, u)
 	}
-	apiKey := openAIKey()
+	if be.Fallback != "" {
+		urls = append(urls, be.Fallback)
+	} else if be.URL == "" {
+		if fb := os.Getenv("AURSCAN_OPENAI_URL_FALLBACK"); fb != "" {
+			urls = append(urls, fb)
+		}
+	}
+	apiKey := nz(be.APIKey, openAIKey())
 	// The model is sent only when AURSCAN_OPENAI_MODEL is set. Leaving it out
 	// lets a routing proxy (LiteLLM and similar) select the model itself, so you
 	// can switch models at the proxy without touching this env var or restarting.
@@ -346,7 +468,7 @@ func callOpenAI(parent context.Context, to time.Duration, instructions, content 
 			{"role": "user", "content": content},
 		},
 	}
-	if model := os.Getenv("AURSCAN_OPENAI_MODEL"); model != "" {
+	if model := nz(be.Model, os.Getenv("AURSCAN_OPENAI_MODEL")); model != "" {
 		payload["model"] = model
 	}
 	body, _ := json.Marshal(payload)
@@ -407,7 +529,8 @@ func callOpenAI(parent context.Context, to time.Duration, instructions, content 
 	return "", Usage{}, lastErr
 }
 
-func callCmd(ctx context.Context, cmd, instructions, content string, estIn int) (string, Usage, error) {
+func callCmd(ctx context.Context, be Backend, instructions, content string, estIn int) (string, Usage, error) {
+	cmd := be.Cmd
 	payload := instructions + "\n\n" + content
 	dbg("cmd backend: %s", cmd)
 	dbgBlock("cmd stdin", payload)

--- a/internal/scan/llm_test.go
+++ b/internal/scan/llm_test.go
@@ -45,7 +45,7 @@ func TestCallOpenAIModelOmittedWhenEnvUnset(t *testing.T) {
 	os.Unsetenv("AURSCAN_OPENAI_MODEL")
 	url, bodyCh := startOpenAIStub(t)
 	t.Setenv("AURSCAN_OPENAI_URL", url)
-	if _, _, err := callOpenAI(context.Background(), time.Second, "sys", "user", 1); err != nil {
+	if _, _, err := callOpenAI(context.Background(), time.Second, Backend{}, "sys", "user", 1); err != nil {
 		t.Fatalf("callOpenAI: %v", err)
 	}
 	if model, ok := requestModel(t, <-bodyCh); ok {
@@ -58,7 +58,7 @@ func TestCallOpenAIModelForwardedWhenEnvSet(t *testing.T) {
 	t.Setenv("AURSCAN_OPENAI_MODEL", want)
 	url, bodyCh := startOpenAIStub(t)
 	t.Setenv("AURSCAN_OPENAI_URL", url)
-	if _, _, err := callOpenAI(context.Background(), time.Second, "sys", "user", 1); err != nil {
+	if _, _, err := callOpenAI(context.Background(), time.Second, Backend{}, "sys", "user", 1); err != nil {
 		t.Fatalf("callOpenAI: %v", err)
 	}
 	if model, ok := requestModel(t, <-bodyCh); !ok || model != want {

--- a/internal/scan/openai_key_test.go
+++ b/internal/scan/openai_key_test.go
@@ -24,7 +24,7 @@ func TestOpenAISendsAPIKey(t *testing.T) {
 	t.Setenv("AURSCAN_OPENAI_URL", srv.URL)
 	t.Setenv("AURSCAN_OPENAI_API_KEY", "sk-litellm-secret")
 	t.Setenv("OPENAI_API_KEY", "")
-	if _, _, err := callOpenAI(context.Background(), 5*time.Second, "sys", "body", 10); err != nil {
+	if _, _, err := callOpenAI(context.Background(), 5*time.Second, Backend{}, "sys", "body", 10); err != nil {
 		t.Fatal(err)
 	}
 	if gotAuth != "Bearer sk-litellm-secret" {
@@ -39,7 +39,7 @@ func TestOpenAIFallsBackToOPENAI_API_KEY(t *testing.T) {
 	t.Setenv("AURSCAN_OPENAI_URL", srv.URL)
 	t.Setenv("AURSCAN_OPENAI_API_KEY", "")
 	t.Setenv("OPENAI_API_KEY", "sk-fallback")
-	if _, _, err := callOpenAI(context.Background(), 5*time.Second, "sys", "body", 10); err != nil {
+	if _, _, err := callOpenAI(context.Background(), 5*time.Second, Backend{}, "sys", "body", 10); err != nil {
 		t.Fatal(err)
 	}
 	if gotAuth != "Bearer sk-fallback" {
@@ -54,7 +54,7 @@ func TestOpenAINoKeyNoHeader(t *testing.T) {
 	t.Setenv("AURSCAN_OPENAI_URL", srv.URL)
 	t.Setenv("AURSCAN_OPENAI_API_KEY", "")
 	t.Setenv("OPENAI_API_KEY", "")
-	if _, _, err := callOpenAI(context.Background(), 5*time.Second, "sys", "body", 10); err != nil {
+	if _, _, err := callOpenAI(context.Background(), 5*time.Second, Backend{}, "sys", "body", 10); err != nil {
 		t.Fatal(err)
 	}
 	if gotAuth != "" {

--- a/internal/scan/verdict.go
+++ b/internal/scan/verdict.go
@@ -73,15 +73,42 @@ func Scan(pkg string, files Files, sig Signals) Result {
 	if ExtraInstructions != "" {
 		instr += "\n\n===== ADDITIONAL USER INSTRUCTIONS =====\n" + ExtraInstructions
 	}
-	raw, u, err := Call(instr, buildPrompt(pkg, files, sig))
-	if err != nil {
-		dbg("scan %s: backend error: %v", pkg, err)
-		return Result{Pkg: pkg, V: failClosed("Scan failed: " + err.Error()), Failed: true}
+	prompt := buildPrompt(pkg, files, sig)
+
+	chain := Backends()
+	if len(chain) == 0 {
+		// Defensive: pipeline.Run gates on PickBackend() before calling Scan.
+		return Result{Pkg: pkg, V: failClosed("no LLM backend configured"), Failed: true}
 	}
-	dbg("scan %s: raw model text (%d bytes):\n%s", pkg, len(raw), raw)
-	v := parseVerdict(raw)
-	failed := v.Confidence == 0 && strings.Contains(v.Summary, "fail-closed")
-	return Result{Pkg: pkg, V: v, Usage: u, Failed: failed}
+	dbg("scan %s: chain (%d backends): %v", pkg, len(chain), chain) // safe: Backend.String() redacts api_key
+
+	// last holds the most recent attempt's fail-closed verdict, returned if the
+	// whole chain is exhausted. For a single-backend chain this reproduces the
+	// previous behaviour exactly (same verdict, summary and Failed flag).
+	var last Result
+	for i, be := range chain {
+		raw, u, err := CallBackend(be, instr, prompt)
+		if err != nil {
+			if i < len(chain)-1 {
+				fmt.Fprintf(os.Stderr, "WARNING: backend %s failed; trying next\n", backendLabel(be))
+			}
+			dbg("scan %s: backend %s error: %v", pkg, be.Kind, err)
+			last = Result{Pkg: pkg, V: failClosed("Scan failed: " + err.Error()), Failed: true}
+			continue
+		}
+		dbg("scan %s: raw model text (%d bytes):\n%s", pkg, len(raw), raw)
+		v, genuine := parseVerdictResult(raw)
+		if !genuine {
+			if i < len(chain)-1 {
+				fmt.Fprintf(os.Stderr, "WARNING: backend %s failed; trying next\n", backendLabel(be))
+			}
+			dbg("scan %s: backend %s returned non-genuine output; trying next", pkg, be.Kind)
+			last = Result{Pkg: pkg, V: v, Usage: u, Failed: true}
+			continue
+		}
+		return Result{Pkg: pkg, V: v, Usage: u}
+	}
+	return last
 }
 
 func buildPrompt(pkg string, files Files, sig Signals) string {
@@ -112,22 +139,35 @@ func buildPrompt(pkg string, files Files, sig Signals) string {
 
 var jsonBlobRe = regexp.MustCompile(`(?s)\{.*\}`)
 
-func parseVerdict(raw string) Verdict {
+// parseVerdictResult extracts the verdict and reports whether it is GENUINE: a
+// real JSON object that yielded a known OK/SUSPICIOUS/MALICIOUS string. The bool
+// is independent of Confidence or Summary text. The three non-genuine cases (no
+// JSON, malformed JSON, unknown verdict string) all return false, so the chain
+// in Scan falls through to the next backend rather than stopping on a backend
+// that did not actually produce a usable verdict.
+func parseVerdictResult(raw string) (Verdict, bool) {
 	blob := jsonBlobRe.FindString(raw)
 	if blob == "" {
 		dbg("parseVerdict: no JSON object found in model output (issue #17)")
-		return failClosed("Scanner returned no parseable result")
+		return failClosed("Scanner returned no parseable result"), false
 	}
 	dbgBlock("parseVerdict: extracted JSON blob", blob)
 	var v Verdict
 	if err := json.Unmarshal([]byte(blob), &v); err != nil {
 		dbg("parseVerdict: json.Unmarshal failed: %v (issue #17)", err)
-		return failClosed("Scanner returned malformed JSON")
+		return failClosed("Scanner returned malformed JSON"), false
 	}
 	if _, ok := Rank[v.Verdict]; !ok {
 		dbg("parseVerdict: unknown verdict %q, downgrading to SUSPICIOUS", v.Verdict)
 		v.Verdict = "SUSPICIOUS"
+		return v, false // contract violation: treat as a non-genuine result
 	}
+	return v, true
+}
+
+// parseVerdict is a thin wrapper kept for callers that only need the verdict.
+func parseVerdict(raw string) Verdict {
+	v, _ := parseVerdictResult(raw)
 	return v
 }
 


### PR DESCRIPTION
## What & why

The README advertises a 6-tier backend preference order, but the code never walked it: `PickBackend` returned exactly one backend and `Scan` failed closed to `SUSPICIOUS` the moment it errored. This implements the **backend fallback chain** discussed in #7 and reported in #35.

- **#35** (HaleTom): a failed Claude CLI immediately failed closed even though Codex was installed — it was never tried. Now the chain tries the next backend first.
- **#7** (multi-backend half): a rate-limited Claude subscription now falls through to a local model / another backend instead of dying on the first request.

## How it works

The chain is **environment-derived backends first** (a pinned `AURSCAN_BACKEND`, otherwise *all* auto-detected backends in the documented order), **then** `~/.config/aurscan/llm1.conf … llmN.conf` in numeric order, de-duplicated. On any per-backend failure — transport/exec error, timeout, or non-genuine output — aurscan prints a one-line `WARNING: backend <x> failed; trying next` and moves on. The first **genuine** verdict (real JSON yielding a known `OK`/`SUSPICIOUS`/`MALICIOUS`) wins. Only when the whole chain is exhausted does it fall closed to `SUSPICIOUS` — unchanged from today.

**Strictly additive.** With no `llmN.conf` and a healthy backend, behaviour is byte-for-byte identical: only the first backend is called on success, total failure still fails closed with the same verdict/exit code, and a *lone* backend failing prints no "trying next" noise. The chain only ever *adds* attempts on failure.

### `llmN.conf` schema (flat `key = value`, no new dependency)

| key | meaning |
|---|---|
| `backend` | `claude` · `codex` · `api` · `openai` · or a `/path/to/exe` (custom command, mirroring `AURSCAN_BACKEND`) |
| `model` | model id for `api` / `codex` / `openai` |
| `url` | endpoint override (`openai` `/chat/completions`, or an Anthropic-compatible `/v1/messages` gateway for `api`) |
| `fallback` | secondary `openai` URL (intra-backend) |
| `api_key` | bearer / `x-api-key` for this backend |

Values are literal; `#`/`;` start a comment only at the start of a line. Secrets are better kept in env vars — aurscan warns on startup if an `api_key`-bearing file is group/other-readable.

## Notable design point

Chain fall-through is decided by a **structural** "genuine verdict" signal (the parser reports whether real JSON produced a known verdict string), **not** the model-controlled `"(fail-closed)"` summary substring the previous code sniffed. Otherwise a backend returning `{"verdict":"unsure"}` (downgraded to `SUSPICIOUS`) would wrongly *stop* the chain.

## Testing

- `make test` (`go vet ./...` + `go test ./...`) — green. New: `internal/config/config_test.go` (parser edge cases: numeric ordering, BOM/CRLF, `=`-in-value, literal values, unreadable-file skip, perm warning), `internal/scan/chain_test.go` (transport/parse/unknown-verdict fall-through, genuine-verdict-stops-chain, cmd fall-through, claude→codex auto-detect, spec-URL precedence, secret-no-leak, exhaustion, single-backend silence), and a pipeline no-backend regression. All pass under `-race`.
- **Live matrix** on the compiled binary: `openai→openai` (fake key → real key) and `openai→claude` fall-through each produced a real verdict; a single fake-key backend failed closed to `SUSPICIOUS`; secret redaction confirmed (`hasKey:yes`, no key in `--debug` output).

## Deferred to follow-ups (flagged for discussion)

1. **Result cache for `--update-check` resume.** This PR fixes the per-invocation rate-limit case (fast-fail then fall through). The *bulk* `--update-check` workload still re-scans every package each run; a content-hash result cache (the other half of #7) is the real fix and is intentionally out of scope here.
2. **Env-var unification.** The env-detected chain is kept byte-for-byte (each `callX` still reads its own legacy env var); the new unified per-field schema applies only to `llmN.conf`. Unifying env onto that schema — and native Azure/Bedrock support (the `api` backend is Anthropic-header-only today) — could be a follow-up.
3. **Total-failure behaviour.** When the whole chain fails, this PR keeps today's fail-closed `SUSPICIOUS` to stay minimal and avoid touching the gate/hook/score logic. A future option could degrade to the static-rules verdict on total failure (the "rules as last resort" idea), with the automated build hooks kept strict (require `INSTALL` / fail closed on a degraded scan) while the standalone CLI stays lenient — happy to add this if you'd prefer it.

**Open question:** in `llmN.conf`, a `backend=/path` value is treated as a custom command (mirroring `AURSCAN_BACKEND=/path`); should a typo'd kind be validated/rejected instead of silently treated as a command path?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
