### PR TITLE
fix: distinguish yay -Qua exit 1 no-results from real errors via stderr

### DIFF
--- a/cmd/aurscan/helpers.go
+++ b/cmd/aurscan/helpers.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os/exec"
 	"strings"
 )
@@ -10,12 +11,17 @@ func run(name string, args ...string) (string, error) {
 	return string(out), err
 }
 
-// runAllowExit1 runs a command and treats exit code 1 as success with empty
-// output. Used for commands like "yay -Qua" that exit 1 to signal "no results".
+// runAllowExit1 runs a command and treats exit code 1 with no stderr output as
+// success with empty output — the "no results" sentinel used by yay -Qua.
+// Exit code 1 with stderr content is a real error (AUR RPC down, db lock,
+// etc.) and is returned as an error to avoid a silent false negative.
 func runAllowExit1(name string, args ...string) (string, error) {
 	out, err := exec.Command(name, args...).Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			if stderr := strings.TrimSpace(string(exitErr.Stderr)); stderr != "" {
+				return "", fmt.Errorf("%s", stderr)
+			}
 			return string(out), nil
 		}
 		return string(out), err


### PR DESCRIPTION
Follow-up to #26 addressing your review comment about overloaded exit codes.

## Problem

`runAllowExit1` treated *any* exit-1 from `yay -Qua` as the "no results" sentinel. But exit 1 also covers genuine failures (AUR RPC unreachable, db lock, malformed response), so `--update-check` would print "No pending AUR updates." and exit 0 — a quiet false negative.

## Fix

`cmd.Output()` populates `ExitError.Stderr` automatically when the caller doesn't set `cmd.Stderr`. We check that field:

- **Exit 1 + empty stderr** → "no results" sentinel, return empty output (unchanged behaviour)
- **Exit 1 + non-empty stderr** → real error, surface it so `--update-check` exits 3 and the caller knows something went wrong

One-line change in `runAllowExit1`; both callers (`updateCheck` and `genFile`) inherit the fix transparently.

