### PR TITLE
feat(config): load ~/.config/aurscan/env at startup

### DIFF
--- a/cmd/aurscan/main.go
+++ b/cmd/aurscan/main.go
@@ -46,6 +46,7 @@ const usage = `usage:
   sparu <paru args...>             transparent paru wrapper (symlink)`
 
 func main() {
+	config.LoadEnvFile()
 	scan.ExtraInstructions = config.ExtraInstructions()
 	scan.ExtraBackends = scan.BackendsFromConfig(config.LLMConfigs())
 	argv0 := os.Args[0]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,37 @@ func Dir() string {
 	return ""
 }
 
+// LoadEnvFile reads KEY=VALUE pairs from <config dir>/env and injects them
+// into the process environment. A variable is only set when it is not already
+// present in the environment, so explicit env vars always win. Lines starting
+// with '#' and blank lines are ignored. Call this once at program startup,
+// before reading any other configuration.
+func LoadEnvFile() {
+	d := Dir()
+	if d == "" {
+		return
+	}
+	b, err := os.ReadFile(filepath.Join(d, "env"))
+	if err != nil {
+		return
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		k = strings.TrimSpace(k)
+		if k == "" || os.Getenv(k) != "" {
+			continue
+		}
+		os.Setenv(k, strings.TrimSpace(v))
+	}
+}
+
 // ExtraInstructions loads the user's additional auditor guidance, if any.
 // Resolution order: AURSCAN_INSTRUCTIONS (a file path), then
 // <config dir>/instructions.md. Returns "" when none is present.


### PR DESCRIPTION
Adds `config.LoadEnvFile()` which reads `KEY=VALUE` pairs from
`<config dir>/env` (i.e. `~/.config/aurscan/env`) and injects them into
the process environment before any other config is resolved.

A variable is only set when it is not already present in the environment,
so explicit shell exports always win over the file.

## Why

Users who run aurscan outside a login shell (GUI launchers, systemd user
units, DE autostart) have no clean way to persist backend config without
editing shell rc files. The existing env vars (`ANTHROPIC_API_KEY`,
`AURSCAN_OPENAI_URL`, etc.) work well but require shell integration.
This file-based fallback covers the gap for non-shell environments.

It is also useful for users who prefer to keep all aurscan config in one
XDG-native place rather than scattered across `.bashrc`/`.zshrc`.

## Behaviour

- File format: `KEY=VALUE`, one per line; `#` comments and blank lines ignored
- Existing env vars always win — the file is a fallback, never an override
- Missing or unreadable file is silently skipped (not an error)
- Called once at program startup, before any backend resolution