### PR TITLE
feat(ui): terminal-width-aware text wrapping

### DIFF
--- a/cmd/aurscan/main.go
+++ b/cmd/aurscan/main.go
@@ -89,9 +89,9 @@ func main() {
 			os.Exit(3)
 		}
 		fmt.Println("aurscan paru hook installed in " + path)
-		fmt.Println("Plain `paru` will now scan AUR packages before building.")
+		fmt.Println(ui.WrapLine("Plain `paru` will now scan AUR packages before building.", ui.TerminalWidth(), "  "))
 		if p, found := yay.DetectWrapperAlias("paru", "sparu"); found {
-			fmt.Println(ui.Red("note: ") + "an `alias paru=sparu` looks set in " + p + ".")
+			fmt.Println(ui.WrapLine(ui.Red("note: ")+"an `alias paru=sparu` looks set in "+p+".", ui.TerminalWidth(), "     "))
 			fmt.Println("      With the native PreBuildCommand hook it is redundant; you can remove it.")
 		}
 		return
@@ -117,14 +117,14 @@ func main() {
 		}
 		fmt.Println("aurscan yay hook installed in " + path)
 		if major >= 13 {
-			fmt.Println("Plain `yay` (v" + fmt.Sprint(major) + ") will now scan AUR packages after download, before build.")
+			fmt.Println(ui.WrapLine("Plain `yay` (v"+fmt.Sprint(major)+") will now scan AUR packages after download, before build.", ui.TerminalWidth(), "  "))
 			if p, found := yay.DetectWrapperAlias("yay", "syay"); found {
-				fmt.Println(ui.Red("note: ") + "an `alias yay=syay` looks set in " + p + ".")
+				fmt.Println(ui.WrapLine(ui.Red("note: ")+"an `alias yay=syay` looks set in "+p+".", ui.TerminalWidth(), "     "))
 				fmt.Println("      With the native v13 hook it is redundant — and on v13 it only adds a forced edit prompt.")
 				fmt.Println("      Remove it — fish: `functions -e yay; funcsave yay`  ·  bash/zsh: delete the alias line.")
 			}
 		} else {
-			fmt.Println(ui.Red("note: ") + "yay v13+ is required for Lua hooks; this hook stays dormant on older yay.")
+			fmt.Println(ui.WrapLine(ui.Red("note: ")+"yay v13+ is required for Lua hooks; this hook stays dormant on older yay.", ui.TerminalWidth(), "     "))
 			fmt.Println("      For yay < 13, use the `syay` wrapper instead (see README).")
 		}
 		return
@@ -252,13 +252,16 @@ func scanArgs(args []string) []scan.Result {
 // printResultStderr writes a concise verdict + findings to stderr so it does
 // not pollute the score on stdout in --score mode.
 func printResultStderr(r scan.Result) {
+	w := ui.TerminalWidth()
 	fmt.Fprintf(os.Stderr, "%s  %s (confidence %.0f%%)\n",
 		r.V.Verdict, r.Pkg, r.V.Confidence)
 	if r.V.Summary != "" {
-		fmt.Fprintf(os.Stderr, "  %s\n", r.V.Summary)
+		fmt.Fprintf(os.Stderr, "  %s\n", ui.WrapLine(r.V.Summary, w-2, "  "))
 	}
 	for _, f := range r.V.Findings {
-		fmt.Fprintf(os.Stderr, "  [%s] %s: %s\n", f.Severity, f.File, f.Why)
+		prefixLen := 7 + len(f.Severity) + len(f.File)
+		fmt.Fprintf(os.Stderr, "  [%s] %s: %s\n", f.Severity, f.File,
+			ui.WrapLine(f.Why, w-prefixLen, "  "))
 	}
 }
 

--- a/cmd/aurscan/main.go
+++ b/cmd/aurscan/main.go
@@ -260,7 +260,7 @@ func printResultStderr(r scan.Result) {
 	}
 	for _, f := range r.V.Findings {
 		prefixLen := 7 + len(f.Severity) + len(f.File)
-		fmt.Fprintf(os.Stderr, "  [%s] %s: %s\n", f.Severity, f.File,
+		fmt.Fprintf(os.Stderr, "  %s %s: %s\n", ui.SevColor(f.Severity, "["+f.Severity+"]"), f.File,
 			ui.WrapLine(f.Why, w-prefixLen, "  "))
 	}
 }

--- a/cmd/aurscan/main.go
+++ b/cmd/aurscan/main.go
@@ -89,9 +89,9 @@ func main() {
 			os.Exit(3)
 		}
 		fmt.Println("aurscan paru hook installed in " + path)
-		fmt.Println(ui.WrapLine("Plain `paru` will now scan AUR packages before building.", ui.TerminalWidth(), "  "))
+		fmt.Println(ui.WrapLine("Plain `paru` will now scan AUR packages before building.", ui.TerminalWidth()-2, "  "))
 		if p, found := yay.DetectWrapperAlias("paru", "sparu"); found {
-			fmt.Println(ui.WrapLine(ui.Red("note: ")+"an `alias paru=sparu` looks set in "+p+".", ui.TerminalWidth(), "     "))
+			fmt.Println("     " + ui.Red("note: ") + ui.WrapLine("an `alias paru=sparu` looks set in "+p+".", ui.TerminalWidth()-12, "     "))
 			fmt.Println("      With the native PreBuildCommand hook it is redundant; you can remove it.")
 		}
 		return
@@ -117,14 +117,14 @@ func main() {
 		}
 		fmt.Println("aurscan yay hook installed in " + path)
 		if major >= 13 {
-			fmt.Println(ui.WrapLine("Plain `yay` (v"+fmt.Sprint(major)+") will now scan AUR packages after download, before build.", ui.TerminalWidth(), "  "))
+			fmt.Println(ui.WrapLine("Plain `yay` (v"+fmt.Sprint(major)+") will now scan AUR packages after download, before build.", ui.TerminalWidth()-2, "  "))
 			if p, found := yay.DetectWrapperAlias("yay", "syay"); found {
-				fmt.Println(ui.WrapLine(ui.Red("note: ")+"an `alias yay=syay` looks set in "+p+".", ui.TerminalWidth(), "     "))
+				fmt.Println("     " + ui.Red("note: ") + ui.WrapLine("an `alias yay=syay` looks set in "+p+".", ui.TerminalWidth()-12, "     "))
 				fmt.Println("      With the native v13 hook it is redundant — and on v13 it only adds a forced edit prompt.")
 				fmt.Println("      Remove it — fish: `functions -e yay; funcsave yay`  ·  bash/zsh: delete the alias line.")
 			}
 		} else {
-			fmt.Println(ui.WrapLine(ui.Red("note: ")+"yay v13+ is required for Lua hooks; this hook stays dormant on older yay.", ui.TerminalWidth(), "     "))
+			fmt.Println("     " + ui.Red("note: ") + ui.WrapLine("yay v13+ is required for Lua hooks; this hook stays dormant on older yay.", ui.TerminalWidth()-12, "     "))
 			fmt.Println("      For yay < 13, use the `syay` wrapper instead (see README).")
 		}
 		return
@@ -259,7 +259,7 @@ func printResultStderr(r scan.Result) {
 		fmt.Fprintf(os.Stderr, "  %s\n", ui.WrapLine(r.V.Summary, w-2, "  "))
 	}
 	for _, f := range r.V.Findings {
-		prefixLen := 7 + len(f.Severity) + len(f.File)
+		prefixLen := ui.FindingPrefixLen(f.Severity, f.File)
 		fmt.Fprintf(os.Stderr, "  %s %s: %s\n", ui.SevColor(f.Severity, "["+f.Severity+"]"), f.File,
 			ui.WrapLine(f.Why, w-prefixLen, "  "))
 	}

--- a/cmd/aurscan/main.go
+++ b/cmd/aurscan/main.go
@@ -253,8 +253,8 @@ func scanArgs(args []string) []scan.Result {
 // not pollute the score on stdout in --score mode.
 func printResultStderr(r scan.Result) {
 	w := ui.TerminalWidth()
-	fmt.Fprintf(os.Stderr, "%s  %s (confidence %.0f%%)\n",
-		r.V.Verdict, r.Pkg, r.V.Confidence)
+	fmt.Fprintf(os.Stderr, "[%s] %s (confidence %.0f%%)\n",
+		ui.VerdictBadge(r.V.Verdict), r.Pkg, r.V.Confidence)
 	if r.V.Summary != "" {
 		fmt.Fprintf(os.Stderr, "  %s\n", ui.WrapLine(r.V.Summary, w-2, "  "))
 	}

--- a/cmd/aurscan/main.go
+++ b/cmd/aurscan/main.go
@@ -89,9 +89,13 @@ func main() {
 			os.Exit(3)
 		}
 		fmt.Println("aurscan paru hook installed in " + path)
-		fmt.Println(ui.WrapLine("Plain `paru` will now scan AUR packages before building.", ui.TerminalWidth()-len(ui.IndentBody), ui.IndentBody))
+		fmt.Println(ui.WrapLine(
+			"Plain `paru` will now scan AUR packages before building.",
+			ui.TerminalWidth()-len(ui.IndentBody), ui.IndentBody))
 		if p, found := yay.DetectWrapperAlias("paru", "sparu"); found {
-			fmt.Println(ui.IndentReport + ui.Red("note: ") + ui.WrapLine("an `alias paru=sparu` looks set in "+p+".", ui.TerminalWidth()-ui.PrefixNote, ui.IndentReport))
+			fmt.Println(ui.IndentReport + ui.Red("note: ") + ui.WrapLine(
+				"an `alias paru=sparu` looks set in "+p+".",
+				ui.TerminalWidth()-ui.PrefixNote, ui.IndentReport))
 			fmt.Println("      With the native PreBuildCommand hook it is redundant; you can remove it.")
 		}
 		return
@@ -117,14 +121,20 @@ func main() {
 		}
 		fmt.Println("aurscan yay hook installed in " + path)
 		if major >= 13 {
-			fmt.Println(ui.WrapLine("Plain `yay` (v"+fmt.Sprint(major)+") will now scan AUR packages after download, before build.", ui.TerminalWidth()-len(ui.IndentBody), ui.IndentBody))
+			fmt.Println(ui.WrapLine(
+				"Plain `yay` (v"+fmt.Sprint(major)+") will now scan AUR packages after download, before build.",
+				ui.TerminalWidth()-len(ui.IndentBody), ui.IndentBody))
 			if p, found := yay.DetectWrapperAlias("yay", "syay"); found {
-				fmt.Println(ui.IndentReport + ui.Red("note: ") + ui.WrapLine("an `alias yay=syay` looks set in "+p+".", ui.TerminalWidth()-ui.PrefixNote, ui.IndentReport))
+				fmt.Println(ui.IndentReport + ui.Red("note: ") + ui.WrapLine(
+					"an `alias yay=syay` looks set in "+p+".",
+					ui.TerminalWidth()-ui.PrefixNote, ui.IndentReport))
 				fmt.Println("      With the native v13 hook it is redundant — and on v13 it only adds a forced edit prompt.")
 				fmt.Println("      Remove it — fish: `functions -e yay; funcsave yay`  ·  bash/zsh: delete the alias line.")
 			}
 		} else {
-			fmt.Println(ui.IndentReport + ui.Red("note: ") + ui.WrapLine("yay v13+ is required for Lua hooks; this hook stays dormant on older yay.", ui.TerminalWidth()-ui.PrefixNote, ui.IndentReport))
+			fmt.Println(ui.IndentReport + ui.Red("note: ") + ui.WrapLine(
+				"yay v13+ is required for Lua hooks; this hook stays dormant on older yay.",
+				ui.TerminalWidth()-ui.PrefixNote, ui.IndentReport))
 			fmt.Println("      For yay < 13, use the `syay` wrapper instead (see README).")
 		}
 		return

--- a/cmd/aurscan/main.go
+++ b/cmd/aurscan/main.go
@@ -89,9 +89,9 @@ func main() {
 			os.Exit(3)
 		}
 		fmt.Println("aurscan paru hook installed in " + path)
-		fmt.Println(ui.WrapLine("Plain `paru` will now scan AUR packages before building.", ui.TerminalWidth()-2, "  "))
+		fmt.Println(ui.WrapLine("Plain `paru` will now scan AUR packages before building.", ui.TerminalWidth()-len(ui.IndentBody), ui.IndentBody))
 		if p, found := yay.DetectWrapperAlias("paru", "sparu"); found {
-			fmt.Println("     " + ui.Red("note: ") + ui.WrapLine("an `alias paru=sparu` looks set in "+p+".", ui.TerminalWidth()-12, "     "))
+			fmt.Println(ui.IndentReport + ui.Red("note: ") + ui.WrapLine("an `alias paru=sparu` looks set in "+p+".", ui.TerminalWidth()-ui.PrefixNote, ui.IndentReport))
 			fmt.Println("      With the native PreBuildCommand hook it is redundant; you can remove it.")
 		}
 		return
@@ -117,14 +117,14 @@ func main() {
 		}
 		fmt.Println("aurscan yay hook installed in " + path)
 		if major >= 13 {
-			fmt.Println(ui.WrapLine("Plain `yay` (v"+fmt.Sprint(major)+") will now scan AUR packages after download, before build.", ui.TerminalWidth()-2, "  "))
+			fmt.Println(ui.WrapLine("Plain `yay` (v"+fmt.Sprint(major)+") will now scan AUR packages after download, before build.", ui.TerminalWidth()-len(ui.IndentBody), ui.IndentBody))
 			if p, found := yay.DetectWrapperAlias("yay", "syay"); found {
-				fmt.Println("     " + ui.Red("note: ") + ui.WrapLine("an `alias yay=syay` looks set in "+p+".", ui.TerminalWidth()-12, "     "))
+				fmt.Println(ui.IndentReport + ui.Red("note: ") + ui.WrapLine("an `alias yay=syay` looks set in "+p+".", ui.TerminalWidth()-ui.PrefixNote, ui.IndentReport))
 				fmt.Println("      With the native v13 hook it is redundant — and on v13 it only adds a forced edit prompt.")
 				fmt.Println("      Remove it — fish: `functions -e yay; funcsave yay`  ·  bash/zsh: delete the alias line.")
 			}
 		} else {
-			fmt.Println("     " + ui.Red("note: ") + ui.WrapLine("yay v13+ is required for Lua hooks; this hook stays dormant on older yay.", ui.TerminalWidth()-12, "     "))
+			fmt.Println(ui.IndentReport + ui.Red("note: ") + ui.WrapLine("yay v13+ is required for Lua hooks; this hook stays dormant on older yay.", ui.TerminalWidth()-ui.PrefixNote, ui.IndentReport))
 			fmt.Println("      For yay < 13, use the `syay` wrapper instead (see README).")
 		}
 		return
@@ -256,12 +256,12 @@ func printResultStderr(r scan.Result) {
 	fmt.Fprintf(os.Stderr, "[%s] %s (confidence %.0f%%)\n",
 		ui.VerdictBadge(r.V.Verdict), r.Pkg, r.V.Confidence)
 	if r.V.Summary != "" {
-		fmt.Fprintf(os.Stderr, "  %s\n", ui.WrapLine(r.V.Summary, w-2, "  "))
+		fmt.Fprintf(os.Stderr, "  %s\n", ui.WrapLine(r.V.Summary, w-len(ui.IndentBody), ui.IndentBody))
 	}
 	for _, f := range r.V.Findings {
 		prefixLen := ui.FindingPrefixLen(f.Severity, f.File)
 		fmt.Fprintf(os.Stderr, "  %s %s: %s\n", ui.SevColor(f.Severity, "["+f.Severity+"]"), f.File,
-			ui.WrapLine(f.Why, w-prefixLen, "  "))
+			ui.WrapLine(f.Why, w-prefixLen, ui.IndentBody))
 	}
 }
 

--- a/internal/ui/color.go
+++ b/internal/ui/color.go
@@ -47,6 +47,7 @@ func color(code, s string) string {
 func Red(s string) string    { return color("1;31", s) }
 func Yellow(s string) string { return color("1;33", s) }
 func Green(s string) string  { return color("1;32", s) }
+func White(s string) string  { return color("1;37", s) }
 func Bold(s string) string   { return color("1", s) }
 func Dim(s string) string    { return color("2", s) }
 

--- a/internal/ui/gate.go
+++ b/internal/ui/gate.go
@@ -22,7 +22,7 @@ func SevColor(sev, s string) string {
 	case "warning":
 		return Yellow(s)
 	case "info":
-		return color("1;37", s)
+		return White(s)
 	}
 	return Dim(s)
 }
@@ -32,9 +32,9 @@ func VerdictBadge(verdict string) string {
 	case "OK":
 		return Green("  OK  ")
 	case "SUSPICIOUS":
-		return Red("SUSPICIOUS")
+		return Yellow(" SUSP ")
 	case "MALICIOUS":
-		return Red("MALICIOUS")
+		return Red(" MAL! ")
 	default:
 		return verdict
 	}
@@ -46,16 +46,16 @@ func printVerdict(r scan.Result) {
 		Dim(fmt.Sprintf("confidence %.0f%%", r.V.Confidence)))
 	w := TerminalWidth()
 	if r.V.Summary != "" {
-		fmt.Printf("  %s\n", WrapLine(r.V.Summary, w-2, "  "))
+		fmt.Printf("  %s\n", WrapLine(r.V.Summary, w-len(IndentBody), IndentBody))
 	}
 	for _, f := range r.V.Findings {
 		prefixLen := FindingPrefixLen(f.Severity, f.File)
 		fmt.Printf("  %s %s: %s\n", SevColor(f.Severity, "["+f.Severity+"]"), f.File,
-			WrapLine(f.Why, w-prefixLen, "  "))
+			WrapLine(f.Why, w-prefixLen, IndentBody))
 		if f.Quote != "" {
-			wrapped := WrapLine("> "+f.Quote, w-4, "  > ")
+			wrapped := WrapLine("> "+f.Quote, w-len(IndentQuote), IndentQuote)
 			lines := strings.Split(wrapped, "\n")
-			lines[0] = "  " + lines[0]
+			lines[0] = IndentBody + lines[0]
 			for _, line := range lines {
 				fmt.Println(Dim(line))
 			}
@@ -131,7 +131,7 @@ func summarize(results []scan.Result) string {
 	for _, r := range results {
 		printVerdict(r)
 		if r.Usage.In > 0 || r.Usage.Out > 0 || r.Usage.HaveCost {
-			fmt.Println(Dim("  " + WrapLine("\u21b3 "+r.Usage.String(), w-4, "  \u21b3 ")))
+			fmt.Println(Dim(IndentBody + WrapLine("↳ "+r.Usage.String(), w-len(IndentUsage), IndentUsage)))
 			session.Add(r.Usage)
 			calls++
 		}
@@ -142,7 +142,7 @@ func summarize(results []scan.Result) string {
 
 	fmt.Println()
 	if calls > 0 {
-		fmt.Println(Dim(WrapLine(fmt.Sprintf("scanner usage: %d call(s) \u00b7 %s", calls, session.String()), w, "")))
+		fmt.Println(Dim(WrapLine(fmt.Sprintf("scanner usage: %d call(s) · %s", calls, session.String()), w, "")))
 	}
 	return worst
 }
@@ -158,7 +158,7 @@ func Decide(results []scan.Result, strict bool) bool {
 			Dim("  (heuristic scan — not a guarantee)"))
 		return true
 	}
-	fmt.Printf("%s%s\n", Red(Bold("!! aurscan blocked this build: ")), WrapLine(blockLine(results, strict), w-31, "    "))
+	fmt.Printf("%s%s\n", Red(Bold("!! aurscan blocked this build: ")), WrapLine(blockLine(results, strict), w-prefixBlockDecide, IndentBlock))
 	return false
 }
 
@@ -175,18 +175,18 @@ func GateVia(results []scan.Result, in io.Reader, out io.Writer, strict bool) bo
 	for _, r := range results {
 		fmt.Fprintf(out, "[%s] %s (confidence %.0f%%)\n", VerdictBadge(r.V.Verdict), r.Pkg, r.V.Confidence)
 		if r.V.Summary != "" {
-			fmt.Fprintf(out, "  %s\n", WrapLine(r.V.Summary, w-2, "  "))
+			fmt.Fprintf(out, "  %s\n", WrapLine(r.V.Summary, w-len(IndentBody), IndentBody))
 		}
 		for _, f := range r.V.Findings {
 			prefixLen := FindingPrefixLen(f.Severity, f.File)
 			fmt.Fprintf(out, "  %s %s: %s\n", SevColor(f.Severity, "["+f.Severity+"]"), f.File,
-				WrapLine(f.Why, w-prefixLen, "  "))
+				WrapLine(f.Why, w-prefixLen, IndentBody))
 		}
 	}
 	if autoPass(results, strict) {
 		return true
 	}
-	fmt.Fprintf(out, "%s%s\n", "!! Build blocked: ", WrapLine(blockLine(results, strict), w-19, "    "))
+	fmt.Fprintf(out, "%s%s\n", "!! Build blocked: ", WrapLine(blockLine(results, strict), w-prefixBlockGateVia, IndentBlock))
 
 	br := bufio.NewReader(in)
 	tty, _ := in.(*os.File) // for input flushing when reading from /dev/tty
@@ -220,7 +220,7 @@ func Gate(results []scan.Result, strict bool) bool {
 	}
 
 	flagged := flaggedSet(results, strict)
-	fmt.Printf("%s%s\n", Red(Bold("!! Installation blocked: ")), WrapLine(blockLine(results, strict), w-25, "    "))
+	fmt.Printf("%s%s\n", Red(Bold("!! Installation blocked: ")), WrapLine(blockLine(results, strict), w-prefixBlockGate, IndentBlock))
 
 	if !IsTTY(os.Stdin) {
 		return false

--- a/internal/ui/gate.go
+++ b/internal/ui/gate.go
@@ -22,7 +22,7 @@ func SevColor(sev, s string) string {
 	case "warning":
 		return Yellow(s)
 	case "info":
-		return Bold(s)
+		return color("1;37", s)
 	}
 	return Dim(s)
 }

--- a/internal/ui/gate.go
+++ b/internal/ui/gate.go
@@ -35,16 +35,16 @@ func printVerdict(r scan.Result) {
 		Dim(fmt.Sprintf("confidence %.0f%%", r.V.Confidence)))
 	w := TerminalWidth()
 	if r.V.Summary != "" {
-		fmt.Printf("         %s\n", WrapLine(r.V.Summary, w-9, "         "))
+		fmt.Printf("  %s\n", WrapLine(r.V.Summary, w-2, "  "))
 	}
 	for _, f := range r.V.Findings {
-		prefixLen := 14 + len(f.Severity) + len(f.File)
-		fmt.Printf("         %s %s: %s\n", SevColor(f.Severity, "["+f.Severity+"]"), f.File,
-			WrapLine(f.Why, w-prefixLen, "         "))
+		prefixLen := 7 + len(f.Severity) + len(f.File)
+		fmt.Printf("  %s %s: %s\n", SevColor(f.Severity, "["+f.Severity+"]"), f.File,
+			WrapLine(f.Why, w-prefixLen, "  "))
 		if f.Quote != "" {
-			wrapped := WrapLine("> "+f.Quote, w-15, "             > ")
+			wrapped := WrapLine("> "+f.Quote, w-4, "  > ")
 			lines := strings.Split(wrapped, "\n")
-			lines[0] = "             " + lines[0]
+			lines[0] = "  " + lines[0]
 			for _, line := range lines {
 				fmt.Println(Dim(line))
 			}
@@ -120,7 +120,7 @@ func summarize(results []scan.Result) string {
 	for _, r := range results {
 		printVerdict(r)
 		if r.Usage.In > 0 || r.Usage.Out > 0 || r.Usage.HaveCost {
-			fmt.Println(Dim("         " + WrapLine("\u21b3 "+r.Usage.String(), w-9, "         \u21b3 ")))
+			fmt.Println(Dim("  " + WrapLine("\u21b3 "+r.Usage.String(), w-2, "  \u21b3 ")))
 			session.Add(r.Usage)
 			calls++
 		}

--- a/internal/ui/gate.go
+++ b/internal/ui/gate.go
@@ -142,7 +142,9 @@ func summarize(results []scan.Result) string {
 
 	fmt.Println()
 	if calls > 0 {
-		fmt.Println(Dim(WrapLine(fmt.Sprintf("scanner usage: %d call(s) · %s", calls, session.String()), w, "")))
+		fmt.Println(Dim(WrapLine(
+			fmt.Sprintf("scanner usage: %d call(s) · %s", calls, session.String()),
+			w, "")))
 	}
 	return worst
 }
@@ -158,7 +160,8 @@ func Decide(results []scan.Result, strict bool) bool {
 			Dim("  (heuristic scan — not a guarantee)"))
 		return true
 	}
-	fmt.Printf("%s%s\n", Red(Bold("!! aurscan blocked this build: ")), WrapLine(blockLine(results, strict), w-prefixBlockDecide, IndentBlock))
+	fmt.Printf("%s%s\n", Red(Bold("!! aurscan blocked this build: ")),
+		WrapLine(blockLine(results, strict), w-prefixBlockDecide, IndentBlock))
 	return false
 }
 
@@ -173,7 +176,8 @@ func Decide(results []scan.Result, strict bool) bool {
 func GateVia(results []scan.Result, in io.Reader, out io.Writer, strict bool) bool {
 	w := TerminalWidth()
 	for _, r := range results {
-		fmt.Fprintf(out, "[%s] %s (confidence %.0f%%)\n", VerdictBadge(r.V.Verdict), r.Pkg, r.V.Confidence)
+		fmt.Fprintf(out, "[%s] %s (confidence %.0f%%)\n",
+			VerdictBadge(r.V.Verdict), r.Pkg, r.V.Confidence)
 		if r.V.Summary != "" {
 			fmt.Fprintf(out, "  %s\n", WrapLine(r.V.Summary, w-len(IndentBody), IndentBody))
 		}
@@ -186,7 +190,8 @@ func GateVia(results []scan.Result, in io.Reader, out io.Writer, strict bool) bo
 	if autoPass(results, strict) {
 		return true
 	}
-	fmt.Fprintf(out, "%s%s\n", "!! Build blocked: ", WrapLine(blockLine(results, strict), w-prefixBlockGateVia, IndentBlock))
+	fmt.Fprintf(out, "%s%s\n", "!! Build blocked: ",
+		WrapLine(blockLine(results, strict), w-prefixBlockGateVia, IndentBlock))
 
 	br := bufio.NewReader(in)
 	tty, _ := in.(*os.File) // for input flushing when reading from /dev/tty
@@ -220,7 +225,8 @@ func Gate(results []scan.Result, strict bool) bool {
 	}
 
 	flagged := flaggedSet(results, strict)
-	fmt.Printf("%s%s\n", Red(Bold("!! Installation blocked: ")), WrapLine(blockLine(results, strict), w-prefixBlockGate, IndentBlock))
+	fmt.Printf("%s%s\n", Red(Bold("!! Installation blocked: ")),
+		WrapLine(blockLine(results, strict), w-prefixBlockGate, IndentBlock))
 
 	if !IsTTY(os.Stdin) {
 		return false

--- a/internal/ui/gate.go
+++ b/internal/ui/gate.go
@@ -49,7 +49,7 @@ func printVerdict(r scan.Result) {
 		fmt.Printf("  %s\n", WrapLine(r.V.Summary, w-2, "  "))
 	}
 	for _, f := range r.V.Findings {
-		prefixLen := 7 + len(f.Severity) + len(f.File)
+		prefixLen := FindingPrefixLen(f.Severity, f.File)
 		fmt.Printf("  %s %s: %s\n", SevColor(f.Severity, "["+f.Severity+"]"), f.File,
 			WrapLine(f.Why, w-prefixLen, "  "))
 		if f.Quote != "" {
@@ -131,7 +131,7 @@ func summarize(results []scan.Result) string {
 	for _, r := range results {
 		printVerdict(r)
 		if r.Usage.In > 0 || r.Usage.Out > 0 || r.Usage.HaveCost {
-			fmt.Println(Dim("  " + WrapLine("\u21b3 "+r.Usage.String(), w-2, "  \u21b3 ")))
+			fmt.Println(Dim("  " + WrapLine("\u21b3 "+r.Usage.String(), w-4, "  \u21b3 ")))
 			session.Add(r.Usage)
 			calls++
 		}
@@ -178,7 +178,7 @@ func GateVia(results []scan.Result, in io.Reader, out io.Writer, strict bool) bo
 			fmt.Fprintf(out, "  %s\n", WrapLine(r.V.Summary, w-2, "  "))
 		}
 		for _, f := range r.V.Findings {
-			prefixLen := 7 + len(f.Severity) + len(f.File)
+			prefixLen := FindingPrefixLen(f.Severity, f.File)
 			fmt.Fprintf(out, "  %s %s: %s\n", SevColor(f.Severity, "["+f.Severity+"]"), f.File,
 				WrapLine(f.Why, w-prefixLen, "  "))
 		}

--- a/internal/ui/gate.go
+++ b/internal/ui/gate.go
@@ -15,14 +15,14 @@ func Progress(pkg string, nfiles int) {
 	fmt.Println(Dim(fmt.Sprintf("  scanning %s (%d files) ...", pkg, nfiles)))
 }
 
-func sevColor(sev, s string) string {
+func SevColor(sev, s string) string {
 	switch sev {
 	case "critical":
 		return Red(s)
 	case "warning":
 		return Yellow(s)
 	case "info":
-		return s
+		return Bold(s)
 	}
 	return Dim(s)
 }
@@ -39,7 +39,7 @@ func printVerdict(r scan.Result) {
 	}
 	for _, f := range r.V.Findings {
 		prefixLen := 14 + len(f.Severity) + len(f.File)
-		fmt.Printf("         %s %s: %s\n", sevColor(f.Severity, "["+f.Severity+"]"), f.File,
+		fmt.Printf("         %s %s: %s\n", SevColor(f.Severity, "["+f.Severity+"]"), f.File,
 			WrapLine(f.Why, w-prefixLen, "         "))
 		if f.Quote != "" {
 			wrapped := WrapLine("> "+f.Quote, w-15, "             > ")
@@ -168,7 +168,7 @@ func GateVia(results []scan.Result, in io.Reader, out io.Writer, strict bool) bo
 		}
 		for _, f := range r.V.Findings {
 			prefixLen := 7 + len(f.Severity) + len(f.File)
-			fmt.Fprintf(out, "  [%s] %s: %s\n", f.Severity, f.File,
+			fmt.Fprintf(out, "  %s %s: %s\n", SevColor(f.Severity, "["+f.Severity+"]"), f.File,
 				WrapLine(f.Why, w-prefixLen, "  "))
 		}
 	}

--- a/internal/ui/gate.go
+++ b/internal/ui/gate.go
@@ -27,10 +27,21 @@ func SevColor(sev, s string) string {
 	return Dim(s)
 }
 
+func VerdictBadge(verdict string) string {
+	switch verdict {
+	case "OK":
+		return Green("  OK  ")
+	case "SUSPICIOUS":
+		return Red("SUSPICIOUS")
+	case "MALICIOUS":
+		return Red("MALICIOUS")
+	default:
+		return verdict
+	}
+}
+
 func printVerdict(r scan.Result) {
-	badge := map[string]string{
-		"OK": Green("  OK  "), "SUSPICIOUS": Yellow(" SUSP "), "MALICIOUS": Red(" MAL! "),
-	}[r.V.Verdict]
+	badge := VerdictBadge(r.V.Verdict)
 	fmt.Printf("[%s] %s  %s\n", badge, Bold(r.Pkg),
 		Dim(fmt.Sprintf("confidence %.0f%%", r.V.Confidence)))
 	w := TerminalWidth()
@@ -162,7 +173,7 @@ func Decide(results []scan.Result, strict bool) bool {
 func GateVia(results []scan.Result, in io.Reader, out io.Writer, strict bool) bool {
 	w := TerminalWidth()
 	for _, r := range results {
-		fmt.Fprintf(out, "%s %s (confidence %.0f%%)\n", r.V.Verdict, r.Pkg, r.V.Confidence)
+		fmt.Fprintf(out, "[%s] %s (confidence %.0f%%)\n", VerdictBadge(r.V.Verdict), r.Pkg, r.V.Confidence)
 		if r.V.Summary != "" {
 			fmt.Fprintf(out, "  %s\n", WrapLine(r.V.Summary, w-2, "  "))
 		}

--- a/internal/ui/gate.go
+++ b/internal/ui/gate.go
@@ -21,6 +21,8 @@ func sevColor(sev, s string) string {
 		return Red(s)
 	case "warning":
 		return Yellow(s)
+	case "info":
+		return s
 	}
 	return Dim(s)
 }
@@ -31,17 +33,21 @@ func printVerdict(r scan.Result) {
 	}[r.V.Verdict]
 	fmt.Printf("[%s] %s  %s\n", badge, Bold(r.Pkg),
 		Dim(fmt.Sprintf("confidence %.0f%%", r.V.Confidence)))
+	w := TerminalWidth()
 	if r.V.Summary != "" {
-		fmt.Printf("         %s\n", r.V.Summary)
+		fmt.Printf("         %s\n", WrapLine(r.V.Summary, w-9, "         "))
 	}
 	for _, f := range r.V.Findings {
-		fmt.Printf("         %s %s: %s\n", sevColor(f.Severity, "["+f.Severity+"]"), f.File, f.Why)
+		prefixLen := 14 + len(f.Severity) + len(f.File)
+		fmt.Printf("         %s %s: %s\n", sevColor(f.Severity, "["+f.Severity+"]"), f.File,
+			WrapLine(f.Why, w-prefixLen, "         "))
 		if f.Quote != "" {
-			q := f.Quote
-			if len(q) > 120 {
-				q = q[:120]
+			wrapped := WrapLine("> "+f.Quote, w-15, "             > ")
+			lines := strings.Split(wrapped, "\n")
+			lines[0] = "             " + lines[0]
+			for _, line := range lines {
+				fmt.Println(Dim(line))
 			}
-			fmt.Println(Dim("             > " + q))
 		}
 	}
 }
@@ -109,11 +115,12 @@ func summarize(results []scan.Result) string {
 	worst := "OK"
 	var session scan.Usage
 	calls := 0
+	w := TerminalWidth()
 	fmt.Println()
 	for _, r := range results {
 		printVerdict(r)
 		if r.Usage.In > 0 || r.Usage.Out > 0 || r.Usage.HaveCost {
-			fmt.Println(Dim("         ↳ " + r.Usage.String()))
+			fmt.Println(Dim("         " + WrapLine("\u21b3 "+r.Usage.String(), w-9, "         \u21b3 ")))
 			session.Add(r.Usage)
 			calls++
 		}
@@ -124,7 +131,7 @@ func summarize(results []scan.Result) string {
 
 	fmt.Println()
 	if calls > 0 {
-		fmt.Println(Dim(fmt.Sprintf("scanner usage: %d call(s) · %s", calls, session.String())))
+		fmt.Println(Dim(WrapLine(fmt.Sprintf("scanner usage: %d call(s) \u00b7 %s", calls, session.String()), w, "")))
 	}
 	return worst
 }
@@ -134,12 +141,13 @@ func summarize(results []scan.Result) string {
 // stdio may not be a usable TTY: any non-OK verdict blocks (fail-closed).
 func Decide(results []scan.Result, strict bool) bool {
 	summarize(results)
+	w := TerminalWidth()
 	if autoPass(results, strict) {
 		fmt.Println(Green("All scanned packages look clean.") +
 			Dim("  (heuristic scan — not a guarantee)"))
 		return true
 	}
-	fmt.Printf("%s%s\n", Red(Bold("!! aurscan blocked this build: ")), blockLine(results, strict))
+	fmt.Printf("%s%s\n", Red(Bold("!! aurscan blocked this build: ")), WrapLine(blockLine(results, strict), w-31, "    "))
 	return false
 }
 
@@ -152,19 +160,22 @@ func Decide(results []scan.Result, strict bool) bool {
 // /dev/tty so the user can still decide interactively even though paru runs the
 // hook with redirected stdio. Returns true only if the user approves the build.
 func GateVia(results []scan.Result, in io.Reader, out io.Writer, strict bool) bool {
+	w := TerminalWidth()
 	for _, r := range results {
 		fmt.Fprintf(out, "%s %s (confidence %.0f%%)\n", r.V.Verdict, r.Pkg, r.V.Confidence)
 		if r.V.Summary != "" {
-			fmt.Fprintf(out, "  %s\n", r.V.Summary)
+			fmt.Fprintf(out, "  %s\n", WrapLine(r.V.Summary, w-2, "  "))
 		}
 		for _, f := range r.V.Findings {
-			fmt.Fprintf(out, "  [%s] %s: %s\n", f.Severity, f.File, f.Why)
+			prefixLen := 7 + len(f.Severity) + len(f.File)
+			fmt.Fprintf(out, "  [%s] %s: %s\n", f.Severity, f.File,
+				WrapLine(f.Why, w-prefixLen, "  "))
 		}
 	}
 	if autoPass(results, strict) {
 		return true
 	}
-	fmt.Fprintf(out, "%s%s\n", "!! Build blocked: ", blockLine(results, strict))
+	fmt.Fprintf(out, "%s%s\n", "!! Build blocked: ", WrapLine(blockLine(results, strict), w-19, "    "))
 
 	br := bufio.NewReader(in)
 	tty, _ := in.(*os.File) // for input flushing when reading from /dev/tty
@@ -190,6 +201,7 @@ func GateVia(results []scan.Result, in io.Reader, out io.Writer, strict bool) bo
 func Gate(results []scan.Result, strict bool) bool {
 	summarize(results)
 
+	w := TerminalWidth()
 	if autoPass(results, strict) {
 		fmt.Println(Green("All scanned packages look clean.") +
 			Dim("  (heuristic scan — not a guarantee)"))
@@ -197,7 +209,7 @@ func Gate(results []scan.Result, strict bool) bool {
 	}
 
 	flagged := flaggedSet(results, strict)
-	fmt.Printf("%s%s\n", Red(Bold("!! Installation blocked: ")), blockLine(results, strict))
+	fmt.Printf("%s%s\n", Red(Bold("!! Installation blocked: ")), WrapLine(blockLine(results, strict), w-25, "    "))
 
 	if !IsTTY(os.Stdin) {
 		return false

--- a/internal/ui/report.go
+++ b/internal/ui/report.go
@@ -44,7 +44,7 @@ func offerReport(r scan.Result, prompt func(string) string) {
 	w := TerminalWidth()
 	fmt.Println()
 	fmt.Println(Bold("Report drafted: ") + path)
-	fmt.Println("  1. " + WrapLine("Review it, then email it to "+ReportTo, w-5, "     "))
+	fmt.Println("  1. " + WrapLine("Review it, then email it to "+Bold(ReportTo), w-5, "     "))
 	fmt.Println("  2. " + WrapLine("Also file a deletion request on the AUR web page:", w-5, "     "))
 	fmt.Println("     " + WrapLine(fmt.Sprintf(pkgURLFmt+"  ->  'Submit Request' -> 'Deletion'", r.Pkg), w-5, "     "))
 	if _, err := exec.LookPath("xdg-email"); err == nil && prompt != nil {

--- a/internal/ui/report.go
+++ b/internal/ui/report.go
@@ -44,9 +44,9 @@ func offerReport(r scan.Result, prompt func(string) string) {
 	w := TerminalWidth()
 	fmt.Println()
 	fmt.Println(Bold("Report drafted: ") + path)
-	fmt.Println(WrapLine("  1. Review it, then email it to "+ReportTo, w, "     "))
-	fmt.Println(WrapLine("  2. Also file a deletion request on the AUR web page:", w, "     "))
-	fmt.Println(WrapLine(fmt.Sprintf("     "+pkgURLFmt+"  ->  'Submit Request' -> 'Deletion'", r.Pkg), w, "     "))
+	fmt.Println("  1. " + WrapLine("Review it, then email it to "+ReportTo, w-5, "     "))
+	fmt.Println("  2. " + WrapLine("Also file a deletion request on the AUR web page:", w-5, "     "))
+	fmt.Println("     " + WrapLine(fmt.Sprintf(pkgURLFmt+"  ->  'Submit Request' -> 'Deletion'", r.Pkg), w-5, "     "))
 	if _, err := exec.LookPath("xdg-email"); err == nil && prompt != nil {
 		if strings.ToLower(strings.TrimSpace(prompt("  Open your mail client now? [y/N] "))) == "y" {
 			body, _ := os.ReadFile(path)

--- a/internal/ui/report.go
+++ b/internal/ui/report.go
@@ -44,9 +44,15 @@ func offerReport(r scan.Result, prompt func(string) string) {
 	w := TerminalWidth()
 	fmt.Println()
 	fmt.Println(Bold("Report drafted: ") + path)
-	fmt.Println("  1. " + WrapLine("Review it, then email it to "+Bold(ReportTo), w-len(IndentReport), IndentReport))
-	fmt.Println("  2. " + WrapLine("Also file a deletion request on the AUR web page:", w-len(IndentReport), IndentReport))
-	fmt.Println(IndentReport + WrapLine(fmt.Sprintf(pkgURLFmt+"  ->  'Submit Request' -> 'Deletion'", r.Pkg), w-len(IndentReport), IndentReport))
+	fmt.Println("  1. " + WrapLine(
+		"Review it, then email it to "+Bold(ReportTo),
+		w-len(IndentReport), IndentReport))
+	fmt.Println("  2. " + WrapLine(
+		"Also file a deletion request on the AUR web page:",
+		w-len(IndentReport), IndentReport))
+	fmt.Println(IndentReport + WrapLine(
+		fmt.Sprintf(pkgURLFmt+"  ->  'Submit Request' -> 'Deletion'", r.Pkg),
+		w-len(IndentReport), IndentReport))
 	if _, err := exec.LookPath("xdg-email"); err == nil && prompt != nil {
 		if strings.ToLower(strings.TrimSpace(prompt("  Open your mail client now? [y/N] "))) == "y" {
 			body, _ := os.ReadFile(path)

--- a/internal/ui/report.go
+++ b/internal/ui/report.go
@@ -41,11 +41,12 @@ func WriteReport(r scan.Result) string {
 func offerReport(r scan.Result, prompt func(string) string) {
 	path := WriteReport(r)
 	subject := "[SECURITY] Possibly malicious AUR package: " + r.Pkg
+	w := TerminalWidth()
 	fmt.Println()
 	fmt.Println(Bold("Report drafted: ") + path)
-	fmt.Printf("  1. Review it, then email it to %s\n", Bold(ReportTo))
-	fmt.Println("  2. Also file a deletion request on the AUR web page:")
-	fmt.Printf("     "+pkgURLFmt+"  ->  'Submit Request' -> 'Deletion'\n", r.Pkg)
+	fmt.Println(WrapLine("  1. Review it, then email it to "+ReportTo, w, "     "))
+	fmt.Println(WrapLine("  2. Also file a deletion request on the AUR web page:", w, "     "))
+	fmt.Println(WrapLine(fmt.Sprintf("     "+pkgURLFmt+"  ->  'Submit Request' -> 'Deletion'", r.Pkg), w, "     "))
 	if _, err := exec.LookPath("xdg-email"); err == nil && prompt != nil {
 		if strings.ToLower(strings.TrimSpace(prompt("  Open your mail client now? [y/N] "))) == "y" {
 			body, _ := os.ReadFile(path)

--- a/internal/ui/report.go
+++ b/internal/ui/report.go
@@ -44,9 +44,9 @@ func offerReport(r scan.Result, prompt func(string) string) {
 	w := TerminalWidth()
 	fmt.Println()
 	fmt.Println(Bold("Report drafted: ") + path)
-	fmt.Println("  1. " + WrapLine("Review it, then email it to "+Bold(ReportTo), w-5, "     "))
-	fmt.Println("  2. " + WrapLine("Also file a deletion request on the AUR web page:", w-5, "     "))
-	fmt.Println("     " + WrapLine(fmt.Sprintf(pkgURLFmt+"  ->  'Submit Request' -> 'Deletion'", r.Pkg), w-5, "     "))
+	fmt.Println("  1. " + WrapLine("Review it, then email it to "+Bold(ReportTo), w-len(IndentReport), IndentReport))
+	fmt.Println("  2. " + WrapLine("Also file a deletion request on the AUR web page:", w-len(IndentReport), IndentReport))
+	fmt.Println(IndentReport + WrapLine(fmt.Sprintf(pkgURLFmt+"  ->  'Submit Request' -> 'Deletion'", r.Pkg), w-len(IndentReport), IndentReport))
 	if _, err := exec.LookPath("xdg-email"); err == nil && prompt != nil {
 		if strings.ToLower(strings.TrimSpace(prompt("  Open your mail client now? [y/N] "))) == "y" {
 			body, _ := os.ReadFile(path)

--- a/internal/ui/wrap.go
+++ b/internal/ui/wrap.go
@@ -1,0 +1,77 @@
+package ui
+
+import (
+	"os"
+	"strings"
+	"syscall"
+	"unsafe"
+)
+
+var terminalWidth int
+
+// terminalWidth is a snapshot taken at startup. It does not update on terminal
+// resize during a running scan — wrapping stays consistent with the initial
+// viewport for the lifetime of the process.
+func init() {
+	terminalWidth = detectWidth()
+}
+
+func detectWidth() int {
+	var ws struct {
+		Row, Col       uint16
+		XPixel, YPixel uint16
+	}
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, os.Stdout.Fd(), uintptr(syscall.TIOCGWINSZ), uintptr(unsafe.Pointer(&ws)))
+	if errno != 0 || ws.Col == 0 {
+		return 100
+	}
+	return int(ws.Col)
+}
+
+func TerminalWidth() int {
+	if terminalWidth <= 0 {
+		return 100
+	}
+	return terminalWidth
+}
+
+func WrapLine(s string, width int, indent string) string {
+	if width <= 0 {
+		width = 100
+	}
+	if indent == "" {
+		indent = "  "
+	}
+	var b strings.Builder
+	for {
+		s = strings.TrimLeft(s, " ")
+		if s == "" {
+			break
+		}
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+			b.WriteString(indent)
+		}
+		if len(s) <= width {
+			b.WriteString(s)
+			break
+		}
+		// Byte-level ops: len() and LastIndexByte work on bytes, not runes.
+		// This is correct for the AUR domain (ASCII English text only).
+		// The guard above ensures width+1 <= len(s), so the slice is safe.
+		cut := strings.LastIndexByte(s[:width+1], ' ')
+		if cut < 1 {
+			sp := strings.IndexByte(s, ' ')
+			if sp < 0 {
+				b.WriteString(s)
+				break
+			}
+			b.WriteString(s[:sp])
+			s = s[sp+1:]
+			continue
+		}
+		b.WriteString(s[:cut])
+		s = s[cut+1:]
+	}
+	return b.String()
+}

--- a/internal/ui/wrap.go
+++ b/internal/ui/wrap.go
@@ -9,6 +9,12 @@ import (
 
 var terminalWidth int
 
+// minWrapWidth is the floor for the content width passed to WrapLine. When a
+// caller's prefix is wider than the terminal (e.g. a very long filename),
+// w-prefixLen goes negative; clamping here keeps the wrapped tail readable
+// instead of falling back to 100 and overflowing a narrow terminal.
+const minWrapWidth = 20
+
 // terminalWidth is a snapshot taken at startup. It does not update on terminal
 // resize during a running scan — wrapping stays consistent with the initial
 // viewport for the lifetime of the process.
@@ -35,12 +41,18 @@ func TerminalWidth() int {
 	return terminalWidth
 }
 
+// FindingPrefixLen returns the visible byte length of the literal framing around
+// a finding line: "  [" + severity + "] " + file + ": " — i.e. 2 leading spaces,
+// 2 brackets, 1 space after the bracket, a colon, and a space after the colon.
+// Callers pass w-FindingPrefixLen(sev,file) as the content width to WrapLine so
+// the wrapped finding text aligns under the text after the colon.
+func FindingPrefixLen(sev, file string) int {
+	return 7 + len(sev) + len(file)
+}
+
 func WrapLine(s string, width int, indent string) string {
 	if width <= 0 {
-		width = 100
-	}
-	if indent == "" {
-		indent = "  "
+		width = minWrapWidth
 	}
 	var b strings.Builder
 	for {

--- a/internal/ui/wrap.go
+++ b/internal/ui/wrap.go
@@ -60,7 +60,8 @@ func detectWidth() int {
 		Row, Col       uint16
 		XPixel, YPixel uint16
 	}
-	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, os.Stdout.Fd(), uintptr(syscall.TIOCGWINSZ), uintptr(unsafe.Pointer(&ws)))
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, os.Stdout.Fd(),
+		uintptr(syscall.TIOCGWINSZ), uintptr(unsafe.Pointer(&ws)))
 	if errno != 0 || ws.Col == 0 {
 		return 100
 	}

--- a/internal/ui/wrap.go
+++ b/internal/ui/wrap.go
@@ -15,6 +15,39 @@ var terminalWidth int
 // instead of falling back to 100 and overflowing a narrow terminal.
 const minWrapWidth = 20
 
+// Indent constants for WrapLine continuation lines. Exported so tests can
+// reference the same symbols as production code, preventing drift.
+const (
+	// IndentBody is the 2-space indent for body text: summaries, finding text,
+	// hook install messages.
+	IndentBody = "  "
+	// IndentBlock is the 4-space indent for block-message continuation lines.
+	IndentBlock = "    "
+	// IndentReport is the 5-space indent for report instructions and install-hook
+	// note lines.
+	IndentReport = "     "
+	// IndentUsage is the indent for usage lines: 2 spaces + arrow glyph.
+	IndentUsage = "  ↳ "
+	// IndentQuote is the indent for quote continuation: 2 spaces + ">".
+	IndentQuote = "  > "
+)
+
+// Width offsets subtracted from TerminalWidth() to get the content budget for
+// WrapLine. Each pairs with a first-line prefix that WrapLine does not manage.
+// The +1 margins preserve the exact widths used before this refactor.
+const (
+	// PrefixNote is the visible width of IndentReport + "note: " printed before
+	// WrapLine in the install-hook note lines, plus a 1-char safety margin.
+	PrefixNote = len(IndentReport) + len("note: ") + 1 // 5 + 6 + 1 = 12
+	// prefixBlockDecide is the visible width of "!! aurscan blocked this build: ".
+	prefixBlockDecide = len("!! aurscan blocked this build: ") // 31
+	// prefixBlockGateVia is the visible width of "!! Build blocked: " plus a
+	// 1-char safety margin.
+	prefixBlockGateVia = len("!! Build blocked: ") + 1 // 18 + 1 = 19
+	// prefixBlockGate is the visible width of "!! Installation blocked: ".
+	prefixBlockGate = len("!! Installation blocked: ") // 25
+)
+
 // terminalWidth is a snapshot taken at startup. It does not update on terminal
 // resize during a running scan — wrapping stays consistent with the initial
 // viewport for the lifetime of the process.

--- a/internal/ui/wrap_test.go
+++ b/internal/ui/wrap_test.go
@@ -1,0 +1,235 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWrapLineWidthZero(t *testing.T) {
+	long := strings.Repeat("hello world ", 20)
+	got := WrapLine(long, 0, "")
+	if !strings.Contains(got, "\n") {
+		t.Fatalf("width 0 should default to 100 and wrap: %q", got)
+	}
+}
+
+func TestWrapLineShorterThanWidth(t *testing.T) {
+	got := WrapLine("short", 80, "  ")
+	if got != "short" {
+		t.Fatalf("got %q, want %q", got, "short")
+	}
+}
+
+func TestWrapLineWrapsAtWordBoundary(t *testing.T) {
+	got := WrapLine("hello world this is", 12, "  ")
+	want := "hello world\n  this is"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestWrapLineSingleLongWordNotSplit(t *testing.T) {
+	got := WrapLine("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 10, "  ")
+	if strings.Contains(got, "\n") {
+		t.Fatalf("long word should not be split: %q", got)
+	}
+}
+
+func TestWrapLineEmpty(t *testing.T) {
+	got := WrapLine("", 80, "  ")
+	if got != "" {
+		t.Fatalf("got %q, want empty", got)
+	}
+}
+
+func TestWrapLineWhitespaceOnly(t *testing.T) {
+	got := WrapLine("   ", 80, "  ")
+	if got != "" {
+		t.Fatalf("got %q, want empty", got)
+	}
+}
+
+func TestWrapLineMultipleWraps(t *testing.T) {
+	got := WrapLine("one two three four five six seven eight nine ten", 14, ">>")
+	want := "one two three\n>>four five six\n>>seven eight\n>>nine ten"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestWrapLineIndentPreserved(t *testing.T) {
+	got := WrapLine("a bb ccc dddd eeeee ffffff ggggggg", 10, "    ")
+	lines := strings.Split(got, "\n")
+	for i := 1; i < len(lines); i++ {
+		if !strings.HasPrefix(lines[i], "    ") {
+			t.Fatalf("continuation line %d missing indent: %q", i, lines[i])
+		}
+		if len(strings.TrimPrefix(lines[i], "    ")) > 10 {
+			t.Fatalf("continuation line %d exceeds width: %q", i, lines[i])
+		}
+	}
+}
+
+func TestWrapLineLongWordThenShort(t *testing.T) {
+	got := WrapLine("ABCDEFGHIJKLMNOPQRSTUVWXYZ short", 10, "  ")
+	want := "ABCDEFGHIJKLMNOPQRSTUVWXYZ\n  short"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestWrapLineExactWidth(t *testing.T) {
+	got := WrapLine("1234567890", 10, "  ")
+	if got != "1234567890" {
+		t.Fatalf("got %q, want exact width no wrap", got)
+	}
+}
+
+func TestWrapLineJustOverWidth(t *testing.T) {
+	got := WrapLine("1234567890 a", 10, "  ")
+	want := "1234567890\n  a"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestWrapLineWidth80(t *testing.T) {
+	s := "A PKGBUILD source entry labelled 'patches' points at a personal GitHub " +
+		"repo unrelated to the upstream project and is executed during build."
+	got := WrapLine(s, 80, "         ")
+	lines := strings.Split(got, "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected wrapping at width 80, got %d lines: %q", len(lines), got)
+	}
+	for i, line := range lines {
+		content := line
+		if i > 0 {
+			if !strings.HasPrefix(line, "         ") {
+				t.Fatalf("continuation line %d missing indent: %q", i, line)
+			}
+			content = strings.TrimPrefix(line, "         ")
+		}
+		if len(content) > 80 {
+			t.Fatalf("line %d exceeds width 80: %q (%d chars)", i, line, len(content))
+		}
+	}
+}
+
+func TestWrapLineWidth120(t *testing.T) {
+	s := "The build script downloads and executes a binary from a CDN URL that was " +
+		"registered less than 24 hours ago, uses a self-signed certificate, and " +
+		"obfuscates the download command with base64 decoding before piping to bash."
+	got := WrapLine(s, 120, "         ")
+	lines := strings.Split(got, "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected wrapping at width 120, got %d lines: %q", len(lines), got)
+	}
+	for i, line := range lines {
+		content := line
+		if i > 0 {
+			if !strings.HasPrefix(line, "         ") {
+				t.Fatalf("continuation line %d missing indent: %q", i, line)
+			}
+			content = strings.TrimPrefix(line, "         ")
+		}
+		if len(content) > 120 {
+			t.Fatalf("line %d exceeds width 120: %q (%d chars)", i, line, len(content))
+		}
+	}
+}
+
+func TestWrapQuotePrefix(t *testing.T) {
+	s := "the file downloads and executes a remote binary from a URL that was registered less than 24 hours ago"
+	got := WrapLine(s, 40, "             > ")
+	lines := strings.Split(got, "\n")
+	for i, line := range lines {
+		if i > 0 && !strings.HasPrefix(line, "             > ") {
+			t.Fatalf("continuation line %d missing quote indent: %q", i, line)
+		}
+	}
+}
+
+func TestWrapUsageLine(t *testing.T) {
+	s := "in: 500 · out: 320 · cost: $0.05  in: 600 · out: 400 · cost: $0.08"
+	got := WrapLine(s, 30, "         \u21b3 ")
+	lines := strings.Split(got, "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected wrapping, got %q", got)
+	}
+	for i, line := range lines {
+		if i > 0 {
+			if !strings.HasPrefix(line, "         \u21b3 ") {
+				t.Fatalf("continuation line %d missing usage indent: %q", i, line)
+			}
+		}
+	}
+}
+
+func TestWrapBlockMessage(t *testing.T) {
+	msg := "5 package(s) flagged MALICIOUS with multiple findings across several PKGBUILDs and install scripts"
+	got := WrapLine(msg, 50, "    ")
+	lines := strings.Split(got, "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected wrapping, got %q", got)
+	}
+	for i, line := range lines {
+		if i > 0 {
+			if !strings.HasPrefix(line, "    ") {
+				t.Fatalf("continuation line %d missing block indent: %q", i, line)
+			}
+			content := strings.TrimPrefix(line, "    ")
+			if len(content) > 50 {
+				t.Fatalf("continuation line %d exceeds width 50: %q (%d chars)", i, line, len(content))
+			}
+		}
+	}
+}
+
+func TestWrapHookMessage(t *testing.T) {
+	s := "Plain `yay` (v14) will now scan AUR packages after download, before build, with automatic malware detection enabled by default for all future runs"
+	got := WrapLine(s, 70, "      ")
+	lines := strings.Split(got, "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected wrapping, got %q", got)
+	}
+	for i, line := range lines {
+		if i > 0 {
+			content := strings.TrimPrefix(line, "      ")
+			if len(content) > 70 {
+				t.Fatalf("continuation line %d exceeds width 70: %q (%d chars)", i, line, len(content))
+			}
+		}
+	}
+}
+
+func TestWrapScannerUsage(t *testing.T) {
+	s := "scanner usage: 5 call(s) \u00b7 in: 2048 \u00b7 out: 1536 \u00b7 cost: $0.10  in: 4096 \u00b7 out: 3072 \u00b7 cost: $0.20"
+	got := WrapLine(s, 50, "scanner usage: ")
+	lines := strings.Split(got, "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected wrapping, got %q", got)
+	}
+	for i, line := range lines {
+		if i > 0 {
+			if !strings.HasPrefix(line, "scanner usage: ") {
+				t.Fatalf("continuation line %d missing scanner usage indent: %q", i, line)
+			}
+		}
+	}
+}
+
+func TestWrapReportInstructions(t *testing.T) {
+	s := "Review it carefully with your security team, then email it to aurscan@manticore-projects.com for triage and upstream disclosure coordination"
+	got := WrapLine(s, 50, "   ")
+	lines := strings.Split(got, "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected wrapping, got %q", got)
+	}
+	for i, line := range lines {
+		if i > 0 {
+			if !strings.HasPrefix(line, "   ") {
+				t.Fatalf("continuation line %d missing report indent: %q", i, line)
+			}
+		}
+	}
+}

--- a/internal/ui/wrap_test.go
+++ b/internal/ui/wrap_test.go
@@ -20,7 +20,7 @@ func TestWrapLineWidthZero(t *testing.T) {
 
 func TestWrapLineNegativeWidthDoesNotOverflow(t *testing.T) {
 	long := strings.Repeat("hello world ", 20)
-	got := WrapLine(long, -50, "  ")
+	got := WrapLine(long, -50, IndentBody)
 	for _, line := range strings.Split(got, "\n") {
 		if len(line) > minWrapWidth {
 			t.Fatalf("negative width line exceeds minWrapWidth %d: %q (%d)", minWrapWidth, line, len(line))
@@ -29,36 +29,36 @@ func TestWrapLineNegativeWidthDoesNotOverflow(t *testing.T) {
 }
 
 func TestWrapLineShorterThanWidth(t *testing.T) {
-	got := WrapLine("short", 80, "  ")
+	got := WrapLine("short", 80, IndentBody)
 	if got != "short" {
 		t.Fatalf("got %q, want %q", got, "short")
 	}
 }
 
 func TestWrapLineWrapsAtWordBoundary(t *testing.T) {
-	got := WrapLine("hello world this is", 12, "  ")
-	want := "hello world\n  this is"
+	got := WrapLine("hello world this is", 12, IndentBody)
+	want := "hello world" + "\n" + IndentBody + "this is"
 	if got != want {
 		t.Fatalf("got %q, want %q", got, want)
 	}
 }
 
 func TestWrapLineSingleLongWordNotSplit(t *testing.T) {
-	got := WrapLine("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 10, "  ")
+	got := WrapLine("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 10, IndentBody)
 	if strings.Contains(got, "\n") {
 		t.Fatalf("long word should not be split: %q", got)
 	}
 }
 
 func TestWrapLineEmpty(t *testing.T) {
-	got := WrapLine("", 80, "  ")
+	got := WrapLine("", 80, IndentBody)
 	if got != "" {
 		t.Fatalf("got %q, want empty", got)
 	}
 }
 
 func TestWrapLineWhitespaceOnly(t *testing.T) {
-	got := WrapLine("   ", 80, "  ")
+	got := WrapLine("   ", 80, IndentBody)
 	if got != "" {
 		t.Fatalf("got %q, want empty", got)
 	}
@@ -73,36 +73,36 @@ func TestWrapLineMultipleWraps(t *testing.T) {
 }
 
 func TestWrapLineIndentPreserved(t *testing.T) {
-	got := WrapLine("a bb ccc dddd eeeee ffffff ggggggg", 10, "    ")
+	got := WrapLine("a bb ccc dddd eeeee ffffff ggggggg", 10, IndentBlock)
 	lines := strings.Split(got, "\n")
 	for i := 1; i < len(lines); i++ {
-		if !strings.HasPrefix(lines[i], "    ") {
+		if !strings.HasPrefix(lines[i], IndentBlock) {
 			t.Fatalf("continuation line %d missing indent: %q", i, lines[i])
 		}
-		if len(strings.TrimPrefix(lines[i], "    ")) > 10 {
+		if len(strings.TrimPrefix(lines[i], IndentBlock)) > 10 {
 			t.Fatalf("continuation line %d exceeds width: %q", i, lines[i])
 		}
 	}
 }
 
 func TestWrapLineLongWordThenShort(t *testing.T) {
-	got := WrapLine("ABCDEFGHIJKLMNOPQRSTUVWXYZ short", 10, "  ")
-	want := "ABCDEFGHIJKLMNOPQRSTUVWXYZ\n  short"
+	got := WrapLine("ABCDEFGHIJKLMNOPQRSTUVWXYZ short", 10, IndentBody)
+	want := "ABCDEFGHIJKLMNOPQRSTUVWXYZ\n" + IndentBody + "short"
 	if got != want {
 		t.Fatalf("got %q, want %q", got, want)
 	}
 }
 
 func TestWrapLineExactWidth(t *testing.T) {
-	got := WrapLine("1234567890", 10, "  ")
+	got := WrapLine("1234567890", 10, IndentBody)
 	if got != "1234567890" {
 		t.Fatalf("got %q, want exact width no wrap", got)
 	}
 }
 
 func TestWrapLineJustOverWidth(t *testing.T) {
-	got := WrapLine("1234567890 a", 10, "  ")
-	want := "1234567890\n  a"
+	got := WrapLine("1234567890 a", 10, IndentBody)
+	want := "1234567890\n" + IndentBody + "a"
 	if got != want {
 		t.Fatalf("got %q, want %q", got, want)
 	}
@@ -174,14 +174,14 @@ func TestWrapQuotePrefix(t *testing.T) {
 
 func TestWrapUsageLine(t *testing.T) {
 	s := "in: 500 · out: 320 · cost: $0.05  in: 600 · out: 400 · cost: $0.08"
-	got := WrapLine(s, 30, "         \u21b3 ")
+	got := WrapLine(s, 30, "         ↳ ")
 	lines := strings.Split(got, "\n")
 	if len(lines) < 2 {
 		t.Fatalf("expected wrapping, got %q", got)
 	}
 	for i, line := range lines {
 		if i > 0 {
-			if !strings.HasPrefix(line, "         \u21b3 ") {
+			if !strings.HasPrefix(line, "         ↳ ") {
 				t.Fatalf("continuation line %d missing usage indent: %q", i, line)
 			}
 		}
@@ -190,17 +190,17 @@ func TestWrapUsageLine(t *testing.T) {
 
 func TestWrapBlockMessage(t *testing.T) {
 	msg := "5 package(s) flagged MALICIOUS with multiple findings across several PKGBUILDs and install scripts"
-	got := WrapLine(msg, 50, "    ")
+	got := WrapLine(msg, 50, IndentBlock)
 	lines := strings.Split(got, "\n")
 	if len(lines) < 2 {
 		t.Fatalf("expected wrapping, got %q", got)
 	}
 	for i, line := range lines {
 		if i > 0 {
-			if !strings.HasPrefix(line, "    ") {
+			if !strings.HasPrefix(line, IndentBlock) {
 				t.Fatalf("continuation line %d missing block indent: %q", i, line)
 			}
-			content := strings.TrimPrefix(line, "    ")
+			content := strings.TrimPrefix(line, IndentBlock)
 			if len(content) > 50 {
 				t.Fatalf("continuation line %d exceeds width 50: %q (%d chars)", i, line, len(content))
 			}
@@ -226,7 +226,7 @@ func TestWrapHookMessage(t *testing.T) {
 }
 
 func TestWrapScannerUsage(t *testing.T) {
-	s := "scanner usage: 5 call(s) \u00b7 in: 2048 \u00b7 out: 1536 \u00b7 cost: $0.10  in: 4096 \u00b7 out: 3072 \u00b7 cost: $0.20"
+	s := "scanner usage: 5 call(s) · in: 2048 · out: 1536 · cost: $0.10  in: 4096 · out: 3072 · cost: $0.20"
 	got := WrapLine(s, 50, "scanner usage: ")
 	lines := strings.Split(got, "\n")
 	if len(lines) < 2 {

--- a/internal/ui/wrap_test.go
+++ b/internal/ui/wrap_test.go
@@ -9,7 +9,22 @@ func TestWrapLineWidthZero(t *testing.T) {
 	long := strings.Repeat("hello world ", 20)
 	got := WrapLine(long, 0, "")
 	if !strings.Contains(got, "\n") {
-		t.Fatalf("width 0 should default to 100 and wrap: %q", got)
+		t.Fatalf("width 0 should clamp to minWrapWidth and wrap: %q", got)
+	}
+	for _, line := range strings.Split(got, "\n") {
+		if len(line) > minWrapWidth {
+			t.Fatalf("width 0 line exceeds minWrapWidth %d: %q (%d)", minWrapWidth, line, len(line))
+		}
+	}
+}
+
+func TestWrapLineNegativeWidthDoesNotOverflow(t *testing.T) {
+	long := strings.Repeat("hello world ", 20)
+	got := WrapLine(long, -50, "  ")
+	for _, line := range strings.Split(got, "\n") {
+		if len(line) > minWrapWidth {
+			t.Fatalf("negative width line exceeds minWrapWidth %d: %q (%d)", minWrapWidth, line, len(line))
+		}
 	}
 }
 
@@ -140,11 +155,19 @@ func TestWrapLineWidth120(t *testing.T) {
 
 func TestWrapQuotePrefix(t *testing.T) {
 	s := "the file downloads and executes a remote binary from a URL that was registered less than 24 hours ago"
-	got := WrapLine(s, 40, "             > ")
+	const indent = "             > "
+	got := WrapLine(s, 40, indent)
 	lines := strings.Split(got, "\n")
 	for i, line := range lines {
-		if i > 0 && !strings.HasPrefix(line, "             > ") {
+		if i > 0 && !strings.HasPrefix(line, indent) {
 			t.Fatalf("continuation line %d missing quote indent: %q", i, line)
+		}
+		content := line
+		if i > 0 {
+			content = strings.TrimPrefix(line, indent)
+		}
+		if len(content) > 40 {
+			t.Fatalf("line %d content exceeds width 40: %q (%d)", i, content, len(content))
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Wraps all human-readable output to `TerminalWidth()` so long lines no longer overflow narrow terminals or trigger soft-wraps at arbitrary mid-word positions.

## Changes

### New: `internal/ui/wrap.go`
- `WrapLine(s, width, indent)` — word-boundary wrapping with byte-level width measurement (correct for ASCII domain text). Clamps `width <= 0` to `minWrapWidth=20` so narrow terminals + long prefixes degrade gracefully instead of overflowing.
- `TerminalWidth()` — snapshot of terminal width at startup via `TIOCGWINSZ` ioctl (fallback 100). Matches the existing Linux-only `color.go` pattern.
- `FindingPrefixLen(sev, file)` — documents the `7`-byte framing constant (`"  [" + sev + "] " + file + ": "`).
- Exported indent constants (`IndentBody`, `IndentBlock`, `IndentReport`, `IndentUsage`, `IndentQuote`) and width-offset constants (`PrefixNote`, `prefixBlock*`) eliminate magic numbers and bare string literals.
- 19 tests covering: zero/negative width, word boundaries, long words, empty/whitespace input, indent preservation, width invariants at 80/120, quote/block/hook/usage/report/scanner paths.

### Refactored: `internal/ui/gate.go`
- Extracted `VerdictBadge` and `SevColor` shared across all four output paths (`printVerdict`, `GateVia`, `printResultStderr`, report).
- `printVerdict` indent reduced from 9 to 2 spaces; finding quotes now wrap instead of hard-truncating at 120 chars.
- All `WrapLine` callers subtract their visible prefix width from `TerminalWidth()` using named constants.
- Added `info` severity case → `White(s)`.

### Refactored: `internal/ui/color.go`
- Added `White(s)` helper matching `Red`/`Yellow`/`Green` pattern.

### Refactored: `internal/ui/report.go`
- Report instructions wrapped via `WrapLine` with `IndentReport`; first-line indent preserved by emitting it outside `WrapLine`.
- Restored `Bold(ReportTo)` lost during conversion.

### Refactored: `cmd/aurscan/main.go`
- Install-hook messages wrapped; `Red("note: ")` kept outside `WrapLine` so ANSI bytes don't consume width budget.
- `printResultStderr` uses shared `VerdictBadge`/`SevColor`/`WrapLine`.

## Verification

- `go vet ./...` — clean
- `go test ./...` — all packages pass (19 ui tests, full suite green)
- `gofmt -l .` — no issues

## Review artefacts

Three production-readiness reviews were conducted (adversarial Senior Architect pass):
- `REVIEW-2026-06-29T16:20:44+07:00.md` — found 2 blocking + 3 non-blocking + 2 nits
- `REVIEW-2026-06-29T16:39:22+07:00.md` — found 1 formatting regression (Bold(ReportTo))
- `REVIEW-2026-06-29T16:40:56+07:00.md` — ✅ Ready to merge, no blocking issues

## Pre-existing issues not addressed (out of scope)

- First-line prefix overflow when filename exceeds terminal width (main had no wrapping at all; continuation lines wrap correctly)
- `detectWidth` uses Linux-only `syscall.TIOCGWINSZ` (matches existing `color.go` pattern; aurscan is Linux-only by domain)