### PR TITLE
fix(ui): streamline INSTALL override prompt (paru path)

### DIFF
--- a/internal/ui/gate.go
+++ b/internal/ui/gate.go
@@ -199,18 +199,17 @@ func GateVia(results []scan.Result, in io.Reader, out io.Writer, strict bool) bo
 		DrainInput(tty) // discard keystrokes buffered before this prompt
 		fmt.Fprint(out, p)
 		line, _ := br.ReadString('\n')
-		return strings.TrimSpace(strings.ToLower(line))
+		return strings.TrimSpace(line)
 	}
+	prompt := White("  Type INSTALL to override the scanner, or [q]uit to exit: ")
 	for {
-		switch ask("  [A]bort (default) / [c]ontinue anyway: ") {
-		case "", "a":
+		switch resp := ask(prompt); {
+		case strings.EqualFold(resp, "INSTALL"):
+			return true
+		case strings.EqualFold(resp, "q"), strings.EqualFold(resp, "quit"):
 			return false
-		case "c":
-			DrainInput(tty)
-			fmt.Fprint(out, "  Type the word INSTALL to override the scanner: ")
-			confirm, _ := br.ReadString('\n')
-			return strings.TrimSpace(confirm) == "INSTALL"
 		}
+		prompt = Red("  (mis-spelled) type INSTALL to override, or [q]uit to exit: ")
 	}
 }
 

--- a/internal/ui/gatevia_test.go
+++ b/internal/ui/gatevia_test.go
@@ -11,21 +11,68 @@ func mal() []scan.Result {
 	return []scan.Result{{Pkg: "evil", V: scan.Verdict{Verdict: "MALICIOUS", Confidence: 95, Summary: "bad"}}}
 }
 
-func TestGateViaAbortDefault(t *testing.T) {
+func TestGateViaRequiresINSTALL(t *testing.T) {
 	var out strings.Builder
-	if GateVia(mal(), strings.NewReader("\n"), &out, false) {
-		t.Fatal("empty input should abort (return false)")
+	// INSTALL proceeds directly, no "c" prefix needed
+	if !GateVia(mal(), strings.NewReader("INSTALL\n"), &out, false) {
+		t.Fatal("INSTALL should proceed")
+	}
+	out.Reset()
+	// case-insensitive: lowercase install also proceeds
+	if !GateVia(mal(), strings.NewReader("install\n"), &out, false) {
+		t.Fatal("lowercase install should proceed")
+	}
+	out.Reset()
+	// mixed case also proceeds
+	if !GateVia(mal(), strings.NewReader("InStAlL\n"), &out, false) {
+		t.Fatal("mixed-case INSTALL should proceed")
 	}
 }
 
-func TestGateViaContinueRequiresINSTALL(t *testing.T) {
+func TestGateViaQuitExits(t *testing.T) {
 	var out strings.Builder
-	if GateVia(mal(), strings.NewReader("c\nnope\n"), &out, false) {
-		t.Fatal("wrong confirm word should not proceed")
+	// q exits (only way out besides INSTALL)
+	if GateVia(mal(), strings.NewReader("q\n"), &out, false) {
+		t.Fatal("q should exit (return false)")
 	}
 	out.Reset()
-	if !GateVia(mal(), strings.NewReader("c\nINSTALL\n"), &out, false) {
-		t.Fatal("c then INSTALL should proceed")
+	// quit exits, case-insensitive
+	if GateVia(mal(), strings.NewReader("QUIT\n"), &out, false) {
+		t.Fatal("QUIT should exit (return false)")
+	}
+}
+
+func TestGateViaMisspellReprompts(t *testing.T) {
+	var out strings.Builder
+	// a typo re-prompts; a following INSTALL still proceeds (state is not lost)
+	if !GateVia(mal(), strings.NewReader("INSTAL\nINSTALL\n"), &out, false) {
+		t.Fatal("mis-spelled INSTALL should re-prompt, then INSTALL should proceed")
+	}
+}
+
+func TestGateViaEmptyReprompts(t *testing.T) {
+	var out strings.Builder
+	// empty input re-prompts (does not abort); a following INSTALL proceeds
+	if !GateVia(mal(), strings.NewReader("\nINSTALL\n"), &out, false) {
+		t.Fatal("empty input should re-prompt, not abort; INSTALL should then proceed")
+	}
+	out.Reset()
+	// empty input then q exits
+	if GateVia(mal(), strings.NewReader("\nq\n"), &out, false) {
+		t.Fatal("empty input should re-prompt; q should then exit")
+	}
+}
+
+func TestGateViaWrongWordReprompts(t *testing.T) {
+	var out strings.Builder
+	// a wrong (non-quit) word re-prompts; a following INSTALL proceeds
+	if !GateVia(mal(), strings.NewReader("nope\nINSTALL\n"), &out, false) {
+		t.Fatal("wrong word should re-prompt, not abort; INSTALL should then proceed")
+	}
+	out.Reset()
+	// a wrong word then q exits
+	if GateVia(mal(), strings.NewReader("nope\nq\n"), &out, false) {
+		t.Fatal("wrong word should re-prompt; q should then exit")
 	}
 }
 


### PR DESCRIPTION
## Summary

Streamlines the `GateVia` interactive prompt (the paru `PreBuildCommand` hook path) so a flagged package no longer requires typing `c` + Enter before `INSTALL`, and a misspelled override word no longer discards the already-reviewed verdicts.

## Problem

When aurscan flags a package, the paru hook prompt asked:

```
  [A]bort (default) / [c]ontinue anyway: c
  Type the word INSTALL to override the scanner: INSTALL
```

Two frictions:

1. **Extra `c<enter>` step.** The `c` menu selection is redundant — the user already intends to override. Forcing a two-step prompt adds keystrokes with no security benefit (the real gate is typing `INSTALL`, not selecting `c`).
2. **Misspelling `INSTALL` exits and loses state.** A single typo (`instal`, trailing space, wrong case) returned `false` immediately, aborting the whole build session. If many PKGBUILDs had already been reviewed, their verdicts and the session usage line were thrown away. Re-running the scan meant re-paying the LLM cost and re-reading every package.

## Changes

### `internal/ui/gate.go` — `GateVia` (paru path only)

- Dropped the `[A]bort / [c]ontinue` menu. The prompt now goes straight to:
  ```
  Type INSTALL to override the scanner, or [q]uit to exit:
  ```
- `INSTALL` is matched **case-insensitively** (`strings.EqualFold`), so `install`, `INSTALL`, `InStAlL` all override.
- The **only** way to exit (return false) is `q` or `quit`, case-insensitive. Empty input and any other misspelling **re-prompt** instead of aborting, so a typo never discards the reviewed state.
- The prompt is rendered in **Info colour** (bright white, `White()`) for visibility; the misspell re-prompt stays **Red** to signal the error.
- The prompt is passed through `ask()` (which calls `DrainInput`) so keystrokes buffered before the prompt are flushed — preventing pre-answered prompts and prompt duplication.

### `internal/ui/gatevia_test.go`

- `TestGateViaRequiresINSTALL`: `INSTALL`, lowercase `install`, and mixed case `InStAlL` all proceed.
- `TestGateViaQuitExits`: `q` and `QUIT` both return false.
- `TestGateViaMisspellReprompts`: a typo followed by `INSTALL` still proceeds.
- `TestGateViaEmptyReprompts`: empty input re-prompts (does not abort); then `INSTALL` proceeds or `q` exits.
- `TestGateViaWrongWordReprompts`: a wrong (non-quit) word re-prompts; then `INSTALL` proceeds or `q` exits.
- `TestGateViaOKProceeds`: OK verdict proceeds without prompting (unchanged).

## Out of scope

The `Gate` function (the `aurscan` / `yay` direct path, with the `[r]eport` mailing-list menu) is **unchanged**. Only the paru hook path was streamlined per the reported UX issue.

## Verification

```
go build ./...
go vet ./...
go test ./...
```

All pass.