### PR TITLE
fix(ui): Fix premature word wrap causing blank space at end of lines

### DIFF
--- a/internal/ui/wrap.go
+++ b/internal/ui/wrap.go
@@ -2,8 +2,10 @@ package ui
 
 import (
 	"os"
+	"regexp"
 	"strings"
 	"syscall"
+	"unicode/utf8"
 	"unsafe"
 )
 
@@ -84,28 +86,57 @@ func FindingPrefixLen(sev, file string) int {
 	return 7 + len(sev) + len(file)
 }
 
+// ansiRe matches ANSI/VT100 escape sequences so they can be stripped from
+// input before wrapping: their bytes would otherwise consume visible-width
+// budget without producing any visible output. LLM-generated findings should
+// never contain these, but a leaked color code or a model that echoes terminal
+// escapes would corrupt the width arithmetic.
+//
+// Source: github.com/acarl005/stripansi (MIT License) — the canonical
+// community regex for stripping ANSI codes. Covers CSI (\x1b[ and the
+// single-byte \x9b form), OSC (terminated by BEL or ST), and the full range
+// of intermediate and final bytes, so it handles 256-color, cursor moves,
+// title-setting, and other non-color escapes that a narrower color-only
+// regex would miss. Kept verbatim rather than vendoring the package to
+// avoid adding a dependency for a single regexp.
+var ansiRe = regexp.MustCompile(`[\x1b\x9b][[\]()#;?]*(?:(?:(?:[a-zA-Z\d]*(?:;[a-zA-Z\d]*)*)?\x07)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PRZcf-ntqry=><~]))`)
+
+// normalizeWrapInput strips ANSI escapes and collapses any run of whitespace
+// (spaces, tabs, newlines) into a single space. LLM output may contain
+// irregular whitespace (multi-space runs from a model, a literal newline
+// inside what should be one sentence, tabs used as separators) which would
+// otherwise produce trailing spaces, ragged lines, or orphan words after
+// wrapping. strings.Fields already trims leading/trailing whitespace.
+func normalizeWrapInput(s string) string {
+	s = ansiRe.ReplaceAllString(s, "")
+	return strings.Join(strings.Fields(s), " ")
+}
+
 func WrapLine(s string, width int, indent string) string {
+	s = normalizeWrapInput(s)
+	if s == "" {
+		return ""
+	}
 	if width <= 0 {
 		width = minWrapWidth
 	}
 	var b strings.Builder
 	for {
-		s = strings.TrimLeft(s, " ")
-		if s == "" {
-			break
-		}
 		if b.Len() > 0 {
 			b.WriteByte('\n')
 			b.WriteString(indent)
 		}
-		if len(s) <= width {
+		// Rune-aware length: a multi-byte UTF-8 rune (e.g. an em dash, 3 bytes)
+		// occupies one visible column, not three. Measuring by bytes under-fills
+		// lines that contain non-ASCII punctuation.
+		if utf8.RuneCountInString(s) <= width {
 			b.WriteString(s)
 			break
 		}
-		// Byte-level ops: len() and LastIndexByte work on bytes, not runes.
-		// This is correct for the AUR domain (ASCII English text only).
-		// The guard above ensures width+1 <= len(s), so the slice is safe.
-		cut := strings.LastIndexByte(s[:width+1], ' ')
+		// Find the last space within the width budget (by rune offset). The
+		// input is already whitespace-normalized, so every space is a single
+		// byte and a single rune; byte indexing is safe here.
+		cut := lastSpaceBefore(s, width)
 		if cut < 1 {
 			sp := strings.IndexByte(s, ' ')
 			if sp < 0 {
@@ -118,6 +149,29 @@ func WrapLine(s string, width int, indent string) string {
 		}
 		b.WriteString(s[:cut])
 		s = s[cut+1:]
+		if s == "" {
+			break
+		}
 	}
 	return b.String()
+}
+
+// lastSpaceBefore returns the byte offset of the last space in s that falls
+// at or before the width-th rune, or -1 if there is none. It iterates runes
+// without allocating a rune slice: the input is whitespace-normalized (single
+// spaces only), so every space is one byte and one rune.
+func lastSpaceBefore(s string, width int) int {
+	var runeIdx, lastSpaceByte int
+	for byteIdx := 0; byteIdx < len(s); {
+		r, size := utf8.DecodeRuneInString(s[byteIdx:])
+		if runeIdx > width {
+			break
+		}
+		if r == ' ' {
+			lastSpaceByte = byteIdx
+		}
+		byteIdx += size
+		runeIdx++
+	}
+	return lastSpaceByte
 }

--- a/internal/ui/wrap_test.go
+++ b/internal/ui/wrap_test.go
@@ -256,3 +256,162 @@ func TestWrapReportInstructions(t *testing.T) {
 		}
 	}
 }
+
+// TestWrapLineNoTrailingSpacesMultiSpaceRun verifies that when the input
+// contains a run of consecutive spaces (an LLM artifact), WrapLine does not
+// emit trailing whitespace on any line. LastIndexByte may land inside the
+// space run; the emitted line must end at the last non-space character.
+// Reproduces the user-reported symptom: a finding line ending in ~47 spaces
+// followed by a short orphan line.
+func TestWrapLineNoTrailingSpacesMultiSpaceRun(t *testing.T) {
+	s := "The patch replaces a checksummed registry crate with a Git branch " +
+		"dependency. Cargo.lock pins commit 98aedbd, but the supplied files " +
+		"cannot independently establish that this repository is" +
+		strings.Repeat(" ", 47) +
+		"the legitimate upstream."
+	got := WrapLine(s, 117, IndentBody)
+	lines := strings.Split(got, "\n")
+	for i, line := range lines {
+		if strings.HasSuffix(line, " ") {
+			t.Fatalf("line %d has trailing spaces (len %d): %q", i, len(line), line)
+		}
+	}
+}
+
+// TestWrapLineNoTrailingSpacesSingleSpace verifies that normal single-space
+// input never produces trailing whitespace — a regression guard for any
+// future change to the cut logic.
+func TestWrapLineNoTrailingSpacesSingleSpace(t *testing.T) {
+	s := "The build script downloads and executes a binary from a CDN URL that " +
+		"was registered less than 24 hours ago, uses a self-signed certificate, " +
+		"and obfuscates the download command with base64 decoding before piping " +
+		"to bash."
+	for _, w := range []int{40, 60, 80, 93, 100, 120, 142} {
+		got := WrapLine(s, w, IndentBody)
+		for i, line := range strings.Split(got, "\n") {
+			if strings.HasSuffix(line, " ") {
+				t.Fatalf("width %d line %d has trailing spaces: %q", w, i, line)
+			}
+		}
+	}
+}
+
+// TestWrapLineNoOrphanAfterSpaceRun verifies that a multi-space run does
+// not produce a ragged last line (e.g. "legitimate upstream." alone) while
+// the previous line holds a stretched-out space run. When a space run is
+// collapsed, content should flow to fill the line naturally.
+func TestWrapLineNoOrphanAfterSpaceRun(t *testing.T) {
+	s := "The patch replaces a checksummed registry crate with a Git branch " +
+		"dependency. Cargo.lock pins commit 98aedbd, but the supplied files " +
+		"cannot independently establish that this repository is" +
+		strings.Repeat(" ", 47) +
+		"the legitimate upstream."
+	for _, w := range []int{119, 120, 121, 122, 142} {
+		got := WrapLine(s, w, IndentBody)
+		lines := strings.Split(got, "\n")
+		for i, line := range lines {
+			content := strings.TrimPrefix(line, IndentBody)
+			// No line should contain an internal run of 2+ spaces when
+			// the input has a space run that should have been collapsed.
+			if strings.Contains(content, "  ") {
+				t.Fatalf("width %d line %d contains an internal space run (%d chars): %q", w, i, len(content), content)
+			}
+		}
+	}
+}
+
+// TestWrapLineCollapsesInternalSpaceRun verifies that an internal run of
+// spaces in the input is treated as a single word boundary for wrapping
+// purposes — no trailing spaces on the line before the run, and no internal
+// space run in any output line's content (excluding the caller's indent).
+func TestWrapLineCollapsesInternalSpaceRun(t *testing.T) {
+	s := "word1 word2" + strings.Repeat(" ", 10) + "word3 word4"
+	got := WrapLine(s, 20, IndentBody)
+	lines := strings.Split(got, "\n")
+	for i, line := range lines {
+		if strings.HasSuffix(line, " ") {
+			t.Fatalf("line %d has trailing spaces: %q", i, line)
+		}
+		// Check the content after the indent, not the full line: the indent
+		// itself is a legitimate run of spaces.
+		content := strings.TrimPrefix(line, IndentBody)
+		if strings.Contains(content, "  ") {
+			t.Fatalf("line %d content contains an internal space run: %q", i, content)
+		}
+	}
+}
+
+// TestWrapLineTabIsWordBoundary verifies that a tab in the input is treated
+// as a word boundary (equivalent to a single space), not emitted literally
+// or allowed to create trailing whitespace.
+func TestWrapLineTabIsWordBoundary(t *testing.T) {
+	s := "repository is\tthe legitimate upstream."
+	got := WrapLine(s, 30, IndentBody)
+	lines := strings.Split(got, "\n")
+	for i, line := range lines {
+		if strings.HasSuffix(line, " ") || strings.HasSuffix(line, "\t") {
+			t.Fatalf("line %d has trailing whitespace: %q", i, line)
+		}
+		if strings.Contains(line, "\t") {
+			t.Fatalf("line %d contains a literal tab: %q", i, line)
+		}
+	}
+}
+
+// TestWrapLineNewlineIsWordBoundary verifies that an embedded newline in the
+// input (an LLM artifact) is treated as a word boundary, not emitted as a
+// literal line break that creates a degenerate short line.
+func TestWrapLineNewlineIsWordBoundary(t *testing.T) {
+	s := "The patch replaces a checksummed registry crate with a Git branch " +
+		"dependency. Cargo.lock pins commit 98aedbd, but the supplied files " +
+		"cannot independently establish that this repository is\nthe legitimate upstream."
+	got := WrapLine(s, 93, IndentBody)
+	lines := strings.Split(got, "\n")
+	for i, line := range lines {
+		content := strings.TrimPrefix(line, IndentBody)
+		if i > 0 && len(content) > 0 && len(content) <= 3 {
+			t.Fatalf("line %d is a short orphan (%d chars) from embedded newline: %q", i, len(content), content)
+		}
+	}
+}
+
+// TestWrapLineANSIDoesNotInflateWidth verifies that if an ANSI escape sequence
+// leaks into f.Why, it does not corrupt the visible width budget. WrapLine
+// operates on bytes; an embedded \x1b[0m (4 bytes) must not consume 4 chars of
+// the visible width or be emitted as trailing/leading invisible bytes.
+func TestWrapLineANSIDoesNotInflateWidth(t *testing.T) {
+	s := "The patch replaces a checksummed registry crate with a Git branch " +
+		"dependency. Cargo.lock pins commit 98aedbd, but the supplied files " +
+		"cannot independently establish that this repository is\x1b[0m the legitimate upstream."
+	got := WrapLine(s, 93, IndentBody)
+	for i, line := range strings.Split(got, "\n") {
+		if strings.Contains(line, "\x1b") {
+			t.Fatalf("line %d contains an ANSI escape byte: %q", i, line)
+		}
+	}
+}
+
+// TestWrapLineNormalizedHasNoLeadingSpace verifies that normalizeWrapInput
+// strips leading whitespace, so lastSpaceBefore never sees a space at byte
+// offset 0 (which would make cut==0 and bypass the long-word fallback).
+func TestWrapLineNormalizedHasNoLeadingSpace(t *testing.T) {
+	for _, s := range []string{" lead", "  lead", "\tlead", "\nlead"} {
+		got := WrapLine(s, 80, IndentBody)
+		if strings.HasPrefix(got, " ") || strings.HasPrefix(got, "\t") {
+			t.Fatalf("output has leading whitespace for input %q: %q", s, got)
+		}
+	}
+}
+
+// TestWrapLineNonASCIIDoesNotInflateWidth verifies that a non-ASCII character
+// (e.g. an em dash, 3 bytes in UTF-8) is measured by its visible rune width
+// (1), not its byte length (3), so it does not under-fill a line.
+func TestWrapLineNonASCIIDoesNotInflateWidth(t *testing.T) {
+	// "word — word" is 11 runes (10 visible + 1 em dash), 13 bytes. With
+	// width=11 it should fit on one line without wrapping.
+	s := "word — word"
+	got := WrapLine(s, 11, IndentBody)
+	if strings.Contains(got, "\n") {
+		t.Fatalf("em dash line wrapped unexpectedly (byte vs rune width mismatch): %q", got)
+	}
+}


### PR DESCRIPTION
## Problem

`WrapLine` in `internal/ui/wrap.go` used `strings.LastIndexByte(s[:width+1], ' ')` for word-boundary detection. When `f.Why` (LLM-generated finding text) contained a multi-space run (an LLM artifact), `LastIndexByte` landed *inside* the space run, emitting ~47 trailing spaces followed by a short orphan line (\"the legitimate upstream.\").

Confirmed root causes:
1. Multi-space runs in LLM output → trailing spaces + orphan words
2. Byte-length `len(s)` measurement → under-filled lines with non-ASCII (em dash = 3 bytes but 1 visible column)
3. Tabs and embedded newlines in LLM output → orphan words
4. ANSI escapes (if ever present in input) would inflate visible width

## Fix

File: `internal/ui/wrap.go`

1. **`normalizeWrapInput`** (new): strips ANSI escapes via the canonical `stripansi` regex (from `github.com/acarl005/stripansi`, MIT), then collapses all whitespace runs (spaces/tabs/newlines) to single spaces via `strings.Join(strings.Fields(s), \" \")`. Trims leading/trailing whitespace.
2. **`ansiRe`**: canonical CSI/OSC strip pattern with a `Source:` comment citing the upstream library. Not vendored — the regex is self-contained and the dependency is MIT-compatible.
3. **Rune-aware width**: replaced `len(s) <= width` with `utf8.RuneCountInString(s)` (allocation-free). Replaced `LastIndexByte` with `lastSpaceBefore` — iterates runes via `utf8.DecodeRuneInString`, returns byte offset of last space at or before the width-th rune.
4. **Wrap loop cleanup**: removed per-iteration `TrimLeft` (normalization handles it once); added `if s == \"\" { break }` after the cut.

## Verification

All 23 tests pass (14 pre-existing + 9 new):

```
ok  	github.com/manticore-projects/aurscan/internal/ui	0.056s
```

New tests target each confirmed hypothesis:
- `TestWrapLineNoTrailingSpacesMultiSpaceRun` — 47-space run at width=117 (the confirmed repro)
- `TestWrapLineNoTrailingSpacesSingleSpace` — regression guard across widths {40,60,80,93,100,120,142}
- `TestWrapLineNoOrphanAfterSpaceRun` — 47-space run at widths {119,120,121,122,142}
- `TestWrapLineCollapsesInternalSpaceRun` — 10-space run, no trailing/internal `\"  \"`
- `TestWrapLineTabIsWordBoundary` — tab treated as word boundary
- `TestWrapLineNewlineIsWordBoundary` — embedded `\\n` treated as word boundary
- `TestWrapLineANSIDoesNotInflateWidth` — `\\x1b[0m` stripped, no ANSI in output
- `TestWrapLineNonASCIIDoesNotInflateWidth` — `\"word — word\"` (11 runes, 13 bytes) fits at width=11
- `TestWrapLineNormalizedHasNoLeadingSpace` — leading whitespace stripped

## Diff scope

```
 internal/ui/wrap.go      |  72 ++++++++++++++++++---
 internal/ui/wrap_test.go | 159 +++++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 222 insertions(+), 9 deletions(-)
```

No changes outside `internal/ui/`. No caller changes. No ANSI injected into `WrapLine` by callers (verified: `SevColor` applied at print site only).

## Related

- Builds on the wrap infrastructure from PR #50 (merged).
- No related issues or competing PRs found.