### PR TITLE
feat: AURSCAN_DISABLE=1 to skip scanning entirely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   difference is explainable. The Codex CLI, which exposes no temperature/seed and
   cannot be made reproducible, is documented as such — prefer the `api` backend
   or a seeded local `openai` model when reproducibility matters.
+- **Global kill switch.** `AURSCAN_DISABLE=1` skips scanning entirely — no
+  rules, no model, no cost — and every package passes through with an instant
+  OK verdict. For re-running an interrupted build, hash-only source changes,
+  or plain user control.
 
 ### Changed
 - **Deterministic verdict from a fixed checklist (discussion #56, Tier 2).** The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   or a seeded local `openai` model when reproducibility matters.
 - **Global kill switch.** `AURSCAN_DISABLE=1` skips scanning entirely — no
   rules, no model, no cost — and every package passes through with an instant
-  OK verdict. For re-running an interrupted build, hash-only source changes,
-  or plain user control.
+  SKIPPED verdict (exit 0). For re-running an interrupted build, hash-only
+  source changes, or plain user control.
 
 ### Changed
 - **Deterministic verdict from a fixed checklist (discussion #56, Tier 2).** The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Global kill switch.** `AURSCAN_DISABLE=1` skips scanning entirely — no
   rules, no model, no cost — and every package passes through with an instant
   SKIPPED verdict (exit 0). For re-running an interrupted build, hash-only
-  source changes, or plain user control.
+  source changes, or plain user control. The kill switch governs the build
+  hooks and the plain scan; `--score` is a scoring query and still runs a real
+  scan.
 
 ### Changed
 - **Deterministic verdict from a fixed checklist (discussion #56, Tier 2).** The

--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ aurscan --debug --score ./PKGBUILD
 | `AURSCAN_TIMEOUT` | `180` | per-request budget in **seconds**; raise it for slow CPU-only models |
 | `AURSCAN_INSTRUCTIONS` | — | path to extra auditor instructions (appended) |
 | `AURSCAN_RULES_ONLY` | — | `1` = static rules only, never call a model |
+| `AURSCAN_DISABLE` | — | `1` = skip scanning entirely; every package gets an instant OK verdict, so builds pass through untouched (re-runs, hash-only changes, or full user control) |
 | `AURSCAN_NO_CACHE` | — | `1` = disable the verdict cache (no read, no write) |
 | `AURSCAN_CACHE_DIR` | `$XDG_CACHE_HOME/aurscan/verdicts` | verdict-cache location |
 | `AURSCAN_CACHE_TTL` | `30` | verdict-cache lifetime in **days**; `0` = never expire |

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Buffered keystrokes are flushed right before the prompt, so mashing <kbd>Enter</
 
 ### Script integration
 
-`--score` scans a single target and maps the result to an exit code: the **0–100 trust score** on success (higher is safer; MALICIOUS 0–33, SUSPICIOUS 34–66, OK 67–100), or `255` if the scan could not complete. The score also prints to stdout while the human-readable verdict goes to stderr, so it is clean to capture.
+`--score` scans a single target and maps the result to an exit code: the **0–100 trust score** on success (higher is safer; MALICIOUS 0–33, SUSPICIOUS 34–66, OK 67–100), or `255` if the scan could not complete. The score also prints to stdout while the human-readable verdict goes to stderr, so it is clean to capture. `--score` is a scoring query, not a build hook: it always runs a real scan and ignores `AURSCAN_DISABLE`.
 
 ```bash
 aurscan --score ./PKGBUILD        # exit code = trust score
@@ -349,7 +349,7 @@ aurscan --debug --score ./PKGBUILD
 | `AURSCAN_TIMEOUT` | `180` | per-request budget in **seconds**; raise it for slow CPU-only models |
 | `AURSCAN_INSTRUCTIONS` | — | path to extra auditor instructions (appended) |
 | `AURSCAN_RULES_ONLY` | — | `1` = static rules only, never call a model |
-| `AURSCAN_DISABLE` | — | `1` = skip scanning entirely; every package gets an instant `SKIPPED` verdict and exit 0, so builds pass through untouched (re-runs, hash-only changes, or full user control) |
+| `AURSCAN_DISABLE` | — | `1` = skip scanning entirely (build hooks and the plain scan); every package gets an instant `SKIPPED` verdict and exit 0, so builds pass through untouched. `--score` is unaffected and still runs a real scan (re-runs, hash-only changes, or full user control) |
 | `AURSCAN_NO_CACHE` | — | `1` = disable the verdict cache (no read, no write) |
 | `AURSCAN_CACHE_DIR` | `$XDG_CACHE_HOME/aurscan/verdicts` | verdict-cache location |
 | `AURSCAN_CACHE_TTL` | `30` | verdict-cache lifetime in **days**; `0` = never expire |

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ aurscan --debug --score ./PKGBUILD
 | `AURSCAN_TIMEOUT` | `180` | per-request budget in **seconds**; raise it for slow CPU-only models |
 | `AURSCAN_INSTRUCTIONS` | — | path to extra auditor instructions (appended) |
 | `AURSCAN_RULES_ONLY` | — | `1` = static rules only, never call a model |
-| `AURSCAN_DISABLE` | — | `1` = skip scanning entirely; every package gets an instant OK verdict, so builds pass through untouched (re-runs, hash-only changes, or full user control) |
+| `AURSCAN_DISABLE` | — | `1` = skip scanning entirely; every package gets an instant `SKIPPED` verdict and exit 0, so builds pass through untouched (re-runs, hash-only changes, or full user control) |
 | `AURSCAN_NO_CACHE` | — | `1` = disable the verdict cache (no read, no write) |
 | `AURSCAN_CACHE_DIR` | `$XDG_CACHE_HOME/aurscan/verdicts` | verdict-cache location |
 | `AURSCAN_CACHE_TTL` | `30` | verdict-cache lifetime in **days**; `0` = never expire |

--- a/cmd/aurscan/disable_test.go
+++ b/cmd/aurscan/disable_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestScanArgsDisabledSkipsCollection(t *testing.T) {
+	t.Setenv("AURSCAN_DISABLE", "1")
+
+	results := scanArgs([]string{t.TempDir()})
+	if len(results) != 1 {
+		t.Fatalf("results = %d, want 1", len(results))
+	}
+	if got := results[0].V.Verdict; got != "SKIPPED" {
+		t.Fatalf("verdict = %q, want SKIPPED", got)
+	}
+}
+
+func TestScoreModeIgnoresDisable(t *testing.T) {
+	t.Setenv("AURSCAN_DISABLE", "1")
+	t.Setenv("AURSCAN_RULES_ONLY", "1")
+
+	path := filepath.Join(t.TempDir(), "PKGBUILD")
+	if err := os.WriteFile(path, []byte("pkgname=clean\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := scoreMode([]string{path}); got != 80 {
+		t.Fatalf("scoreMode exit = %d, want 80 from a real rules-only scan", got)
+	}
+}

--- a/cmd/aurscan/main.go
+++ b/cmd/aurscan/main.go
@@ -348,7 +348,7 @@ func scoreMode(rest []string) int {
 		fmt.Fprintln(os.Stderr, ui.Red("error: ")+err.Error())
 		return 255
 	}
-	res := pipeline.Run(name, files, "")
+	res := pipeline.RunScored(name, files, "")
 	// Show the verdict + findings on stderr (does not pollute the score stdout).
 	printResultStderr(res)
 	if res.Failed {

--- a/cmd/aurscan/main.go
+++ b/cmd/aurscan/main.go
@@ -266,6 +266,10 @@ func scanArgs(args []string) []scan.Result {
 // printResultStderr writes a concise verdict + findings to stderr so it does
 // not pollute the score on stdout in --score mode.
 func printResultStderr(r scan.Result) {
+	if r.V.Verdict == "SKIPPED" {
+		fmt.Fprintf(os.Stderr, "[%s] %s - %s\n", ui.VerdictBadge(r.V.Verdict), r.Pkg, r.V.Summary)
+		return
+	}
 	w := ui.TerminalWidth()
 	fmt.Fprintf(os.Stderr, "[%s] %s (confidence %.0f%%)\n",
 		ui.VerdictBadge(r.V.Verdict), r.Pkg, r.V.Confidence)

--- a/cmd/aurscan/main.go
+++ b/cmd/aurscan/main.go
@@ -238,6 +238,13 @@ func updateCheck() []scan.Result {
 
 func scanArgs(args []string) []scan.Result {
 	var results []scan.Result
+	if pipeline.Disabled() {
+		for _, a := range args {
+			abs, _ := filepath.Abs(a)
+			results = append(results, pipeline.SkippedResult(filepath.Base(abs)))
+		}
+		return results
+	}
 	var names []string
 	for _, a := range args {
 		if fi, err := os.Stat(a); err == nil && fi.IsDir() {

--- a/internal/aur/aur.go
+++ b/internal/aur/aur.go
@@ -202,6 +202,13 @@ func maxPkgs() int {
 // closure (official-repo deps are skipped). Progress is reported via the
 // optional onScan callback before each package is sent to the model.
 func ScanRecursive(roots []string, onScan func(pkg string, nfiles int)) []scan.Result {
+	if pipeline.Disabled() {
+		results := make([]scan.Result, len(roots))
+		for i, pkg := range roots {
+			results[i] = pipeline.SkippedResult(pkg)
+		}
+		return results
+	}
 	var results []scan.Result
 	queue := append([]string(nil), roots...)
 	seen := map[string]bool{}

--- a/internal/aur/aur_test.go
+++ b/internal/aur/aur_test.go
@@ -1,0 +1,36 @@
+package aur
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestScanRecursiveDisabledSkipsNetwork(t *testing.T) {
+	t.Setenv("AURSCAN_DISABLE", "1")
+
+	called := false
+	oldTransport := client.Transport
+	client.Transport = roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		called = true
+		return nil, errors.New("unexpected network request")
+	})
+	t.Cleanup(func() { client.Transport = oldTransport })
+
+	results := ScanRecursive([]string{"example"}, nil)
+	if called {
+		t.Fatal("AUR request made while scanning is disabled")
+	}
+	if len(results) != 1 {
+		t.Fatalf("results = %d, want 1", len(results))
+	}
+	if got := results[0].V.Verdict; got != "SKIPPED" {
+		t.Fatalf("verdict = %q, want SKIPPED", got)
+	}
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -22,7 +22,7 @@ func Run(pkg string, files scan.Files, rep string) scan.Result {
 	// build, when only source-hash changes are expected, or for user control.
 	if Disabled() {
 		return scan.Result{Pkg: pkg, V: scan.Verdict{
-			Verdict:    "OK",
+			Verdict:    "SKIPPED",
 			Confidence: 100,
 			Summary:    "scanning disabled (AURSCAN_DISABLE=1)",
 		}}
@@ -51,7 +51,7 @@ func Run(pkg string, files scan.Files, rep string) scan.Result {
 func AllowRulesOnly() bool { return os.Getenv("AURSCAN_RULES_ONLY") == "1" }
 
 // Disabled reports whether scanning has been switched off entirely
-// (AURSCAN_DISABLE=1). Every package then gets an immediate OK verdict, so
+// (AURSCAN_DISABLE=1). Every package then gets an immediate SKIPPED verdict, so
 // builds pass through untouched: no rules, no model call, no cost.
 func Disabled() bool { return os.Getenv("AURSCAN_DISABLE") == "1" }
 

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -17,6 +17,17 @@ import (
 
 // Run scans one package. rep is optional pre-formatted reputation text.
 func Run(pkg string, files scan.Files, rep string) scan.Result {
+	// Scanning disabled (AURSCAN_DISABLE=1): no rules, no model, no cost —
+	// every package passes through untouched. Useful to re-run an interrupted
+	// build, when only source-hash changes are expected, or for user control.
+	if Disabled() {
+		return scan.Result{Pkg: pkg, V: scan.Verdict{
+			Verdict:    "OK",
+			Confidence: 100,
+			Summary:    "scanning disabled (AURSCAN_DISABLE=1)",
+		}}
+	}
+
 	hits := rules.Scan(files)
 
 	// Forced rules-only mode (AURSCAN_RULES_ONLY=1): skip the model entirely.
@@ -38,6 +49,11 @@ func Run(pkg string, files scan.Files, rep string) scan.Result {
 // (AURSCAN_RULES_ONLY=1) — useful to force the cheap path even when a backend
 // exists, e.g. in tight CI loops.
 func AllowRulesOnly() bool { return os.Getenv("AURSCAN_RULES_ONLY") == "1" }
+
+// Disabled reports whether scanning has been switched off entirely
+// (AURSCAN_DISABLE=1). Every package then gets an immediate OK verdict, so
+// builds pass through untouched: no rules, no model call, no cost.
+func Disabled() bool { return os.Getenv("AURSCAN_DISABLE") == "1" }
 
 // RunRulesOnly scans using only the static catalog (no model call, no cost).
 func RunRulesOnly(pkg string, files scan.Files) scan.Result {

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -15,12 +15,24 @@ import (
 	"github.com/manticore-projects/aurscan/internal/scan"
 )
 
-// Run scans one package. rep is optional pre-formatted reputation text.
+// Run scans one package, honoring AURSCAN_DISABLE. rep is optional
+// pre-formatted reputation text.
 func Run(pkg string, files scan.Files, rep string) scan.Result {
+	return run(pkg, files, rep, true)
+}
+
+// RunScored scans one package for --score: an explicit scoring query always
+// runs a real scan and ignores AURSCAN_DISABLE — the kill switch governs the
+// yay/paru build hooks and the plain scan gate, not scoring.
+func RunScored(pkg string, files scan.Files, rep string) scan.Result {
+	return run(pkg, files, rep, false)
+}
+
+func run(pkg string, files scan.Files, rep string, honorDisable bool) scan.Result {
 	// Scanning disabled (AURSCAN_DISABLE=1): no rules, no model, no cost —
 	// every package passes through untouched. Useful to re-run an interrupted
 	// build, when only source-hash changes are expected, or for user control.
-	if Disabled() {
+	if honorDisable && Disabled() {
 		return scan.Result{Pkg: pkg, V: scan.Verdict{
 			Verdict:    "SKIPPED",
 			Confidence: 100,

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -33,11 +33,7 @@ func run(pkg string, files scan.Files, rep string, honorDisable bool) scan.Resul
 	// every package passes through untouched. Useful to re-run an interrupted
 	// build, when only source-hash changes are expected, or for user control.
 	if honorDisable && Disabled() {
-		return scan.Result{Pkg: pkg, V: scan.Verdict{
-			Verdict:    "SKIPPED",
-			Confidence: 100,
-			Summary:    "scanning disabled (AURSCAN_DISABLE=1)",
-		}}
+		return SkippedResult(pkg)
 	}
 
 	hits := rules.Scan(files)
@@ -66,6 +62,15 @@ func AllowRulesOnly() bool { return os.Getenv("AURSCAN_RULES_ONLY") == "1" }
 // (AURSCAN_DISABLE=1). Every package then gets an immediate SKIPPED verdict, so
 // builds pass through untouched: no rules, no model call, no cost.
 func Disabled() bool { return os.Getenv("AURSCAN_DISABLE") == "1" }
+
+// SkippedResult returns the pass-through result for a disabled scan.
+func SkippedResult(pkg string) scan.Result {
+	return scan.Result{Pkg: pkg, V: scan.Verdict{
+		Verdict:    "SKIPPED",
+		Confidence: 100,
+		Summary:    "scanning disabled (AURSCAN_DISABLE=1)",
+	}}
+}
 
 // RunRulesOnly scans using only the static catalog (no model call, no cost).
 func RunRulesOnly(pkg string, files scan.Files) scan.Result {

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -44,6 +44,29 @@ func TestDisabledShortCircuits(t *testing.T) {
 	}
 }
 
+// TestScoreIgnoresDisable proves --score runs a real scan even when
+// AURSCAN_DISABLE=1: the kill switch governs the build hooks and the plain
+// scan gate, not the explicit scoring query.
+func TestScoreIgnoresDisable(t *testing.T) {
+	t.Setenv("AURSCAN_DISABLE", "1")
+	t.Setenv("PATH", t.TempDir()) // no claude/codex
+	t.Setenv("AURSCAN_BACKEND", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("AURSCAN_OPENAI_URL", "")
+	t.Setenv("AURSCAN_CONFIG_DIR", t.TempDir()) // empty: no llmN.conf
+	scan.ExtraBackends = nil
+	t.Cleanup(func() { scan.ExtraBackends = nil })
+
+	files := scan.Files{"PKGBUILD": `build() { npm install atomic-lockfile; }`}
+	r := RunScored("evil", files, "")
+	if r.V.Verdict != "MALICIOUS" {
+		t.Fatalf("verdict = %q, want MALICIOUS", r.V.Verdict)
+	}
+	if len(r.V.Findings) == 0 {
+		t.Fatal("expected findings: --score must not skip the scan")
+	}
+}
+
 // TestRunNoBackendNote pins down the unchanged State A: with no backend
 // configured at all (no env backend, no llmN.conf), Run returns the static-rules
 // verdict carrying the original "no LLM backend configured" note — NOT the

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -27,6 +27,23 @@ package() { make DESTDIR="$pkgdir" install; }`}
 	}
 }
 
+// TestDisabledShortCircuits proves AURSCAN_DISABLE=1 skips even a package that
+// would trip the static rules: instant OK, no findings.
+func TestDisabledShortCircuits(t *testing.T) {
+	t.Setenv("AURSCAN_DISABLE", "1")
+	files := scan.Files{"PKGBUILD": `build() { npm install atomic-lockfile; }`}
+	r := Run("evil", files, "")
+	if r.V.Verdict != "OK" {
+		t.Fatalf("verdict = %q, want OK", r.V.Verdict)
+	}
+	if len(r.V.Findings) != 0 {
+		t.Fatalf("expected no findings while disabled, got %d", len(r.V.Findings))
+	}
+	if !strings.Contains(r.V.Summary, "AURSCAN_DISABLE") {
+		t.Fatalf("summary = %q, want the AURSCAN_DISABLE note", r.V.Summary)
+	}
+}
+
 // TestRunNoBackendNote pins down the unchanged State A: with no backend
 // configured at all (no env backend, no llmN.conf), Run returns the static-rules
 // verdict carrying the original "no LLM backend configured" note — NOT the

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -28,13 +28,13 @@ package() { make DESTDIR="$pkgdir" install; }`}
 }
 
 // TestDisabledShortCircuits proves AURSCAN_DISABLE=1 skips even a package that
-// would trip the static rules: instant OK, no findings.
+// would trip the static rules: instant SKIPPED verdict, no findings.
 func TestDisabledShortCircuits(t *testing.T) {
 	t.Setenv("AURSCAN_DISABLE", "1")
 	files := scan.Files{"PKGBUILD": `build() { npm install atomic-lockfile; }`}
 	r := Run("evil", files, "")
-	if r.V.Verdict != "OK" {
-		t.Fatalf("verdict = %q, want OK", r.V.Verdict)
+	if r.V.Verdict != "SKIPPED" {
+		t.Fatalf("verdict = %q, want SKIPPED", r.V.Verdict)
 	}
 	if len(r.V.Findings) != 0 {
 		t.Fatalf("expected no findings while disabled, got %d", len(r.V.Findings))

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -1,6 +1,8 @@
 package pipeline
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -41,6 +43,48 @@ func TestDisabledShortCircuits(t *testing.T) {
 	}
 	if !strings.Contains(r.V.Summary, "AURSCAN_DISABLE") {
 		t.Fatalf("summary = %q, want the AURSCAN_DISABLE note", r.V.Summary)
+	}
+}
+
+// TestDisabledNeverInvokesBackend proves the kill switch really stops all
+// scanning: with AURSCAN_DISABLE=1 the model CLI on PATH is never executed
+// (a fake claude would write a marker); without it, the same setup runs and
+// the marker appears.
+func TestDisabledNeverInvokesBackend(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "backend-was-run")
+	script := "#!/bin/sh\n: > '" + marker + "'\nexit 1\n"
+	if err := os.WriteFile(filepath.Join(dir, "claude"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+	t.Setenv("AURSCAN_BACKEND", "")
+	t.Setenv("AURSCAN_RULES_ONLY", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("AURSCAN_OPENAI_URL", "")
+	t.Setenv("AURSCAN_CONFIG_DIR", t.TempDir()) // empty: no llmN.conf
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())     // fresh verdict cache: no stale hits
+	scan.ExtraBackends = nil
+	t.Cleanup(func() { scan.ExtraBackends = nil })
+
+	files := scan.Files{"PKGBUILD": `build() { npm install atomic-lockfile; }`}
+
+	t.Setenv("AURSCAN_DISABLE", "1")
+	r := Run("evil", files, "")
+	if r.V.Verdict != "SKIPPED" {
+		t.Fatalf("verdict = %q, want SKIPPED", r.V.Verdict)
+	}
+	if _, err := os.Stat(marker); err == nil {
+		t.Fatal("model backend was invoked while scanning is disabled")
+	}
+
+	t.Setenv("AURSCAN_DISABLE", "")
+	r = Run("evil", files, "")
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("sanity: backend marker missing after an enabled run: %v", err)
+	}
+	if !r.Failed {
+		t.Fatalf("sanity: fake backend exits 1, want Failed=true, got verdict %q", r.V.Verdict)
 	}
 }
 

--- a/internal/scan/verdict.go
+++ b/internal/scan/verdict.go
@@ -38,7 +38,7 @@ type Verdict struct {
 }
 
 // Rank orders verdicts so callers can compute the worst across packages.
-var Rank = map[string]int{"OK": 0, "SUSPICIOUS": 1, "MALICIOUS": 2}
+var Rank = map[string]int{"OK": 0, "SUSPICIOUS": 1, "MALICIOUS": 2, "SKIPPED": 0}
 
 // Result pairs a package name with its verdict and the usage it cost.
 // Failed is true when the scan could not be completed (backend/comms error or
@@ -374,6 +374,8 @@ func TrustScore(v Verdict) int {
 		return 34 + round((100.0-c)*32.0/100.0)
 	case "MALICIOUS":
 		return round((100.0 - c) * 33.0 / 100.0)
+	case "SKIPPED":
+		return 0 // no trust judgement; exit 0 so disabled runs pass cleanly
 	default:
 		return 0
 	}

--- a/internal/ui/gate.go
+++ b/internal/ui/gate.go
@@ -7,11 +7,17 @@ import (
 	"os"
 	"strings"
 
+	"github.com/manticore-projects/aurscan/internal/pipeline"
 	"github.com/manticore-projects/aurscan/internal/scan"
 )
 
-// Progress prints the "scanning ..." line before a model call.
+// Progress prints the "scanning ..." line before a model call. It is silent
+// while scanning is disabled (AURSCAN_DISABLE=1): nothing is scanned, so
+// nothing is announced.
 func Progress(pkg string, nfiles int) {
+	if pipeline.Disabled() {
+		return
+	}
 	fmt.Println(Dim(fmt.Sprintf("  scanning %s (%d files) ...", pkg, nfiles)))
 }
 

--- a/internal/ui/gate.go
+++ b/internal/ui/gate.go
@@ -99,10 +99,10 @@ func cleanLine(results []scan.Result) string {
 		Dim("  (heuristic scan — not a guarantee)")
 }
 
-// autoPass reports whether results may proceed without any prompt. A non-OK
-// verdict never auto-passes. In strict mode (the unattended build-hook path) a
-// fallback-produced OK does not auto-pass either: the primary scanner was
-// unavailable, so a degraded clean verdict still requires confirmation.
+// autoPass reports whether results may proceed without any prompt. Only OK and
+// explicit SKIPPED results auto-pass. In strict mode (the unattended build-hook
+// path) a fallback-produced OK does not auto-pass either: the primary scanner
+// was unavailable, so a degraded clean verdict still requires confirmation.
 func autoPass(results []scan.Result, strict bool) bool {
 	for _, r := range results {
 		if r.V.Verdict != "OK" && r.V.Verdict != "SKIPPED" {
@@ -115,8 +115,8 @@ func autoPass(results []scan.Result, strict bool) bool {
 	return true
 }
 
-// flaggedSet is the set of results that block an auto-pass: every non-OK
-// verdict, plus (in strict mode) any fallback-produced OK.
+// flaggedSet is the set of results that block an auto-pass: every verdict other
+// than OK or explicit SKIPPED, plus (in strict mode) any fallback-produced OK.
 func flaggedSet(results []scan.Result, strict bool) []scan.Result {
 	var out []scan.Result
 	for _, r := range results {
@@ -187,7 +187,8 @@ func summarize(results []scan.Result) string {
 
 // Decide prints verdicts and usage, then returns whether it is safe to proceed
 // WITHOUT any interactive prompt. Used by the paru PreBuildCommand hook, whose
-// stdio may not be a usable TTY: any non-OK verdict blocks (fail-closed).
+// stdio may not be a usable TTY: adverse verdicts block (fail-closed); explicit
+// SKIPPED is the user-requested pass-through exception.
 func Decide(results []scan.Result, strict bool) bool {
 	summarize(results)
 	w := TerminalWidth()
@@ -201,7 +202,7 @@ func Decide(results []scan.Result, strict bool) bool {
 }
 
 // Gate prints every verdict, the accumulated session usage/cost, and — if any
-// package is non-OK — blocks. On a TTY it offers abort / report / override;
+// package has an adverse verdict — blocks. On a TTY it offers abort / report / override;
 // off a TTY (scripts, the editor hook in a non-interactive yay) it always
 // blocks. Returns true only if it is safe/approved to proceed.
 // GateVia is Gate's interactive core operating over an explicit reader/writer

--- a/internal/ui/gate.go
+++ b/internal/ui/gate.go
@@ -35,6 +35,8 @@ func VerdictBadge(verdict string) string {
 		return Yellow(" SUSP ")
 	case "MALICIOUS":
 		return Red(" MAL! ")
+	case "SKIPPED":
+		return Dim("SKIPPED")
 	default:
 		return verdict
 	}
@@ -66,13 +68,34 @@ func printVerdict(r scan.Result) {
 	}
 }
 
+// allSkipped reports whether every result is SKIPPED (AURSCAN_DISABLE=1).
+func allSkipped(results []scan.Result) bool {
+	skipped := false
+	for _, r := range results {
+		if r.V.Verdict != "SKIPPED" {
+			return false
+		}
+		skipped = true
+	}
+	return skipped
+}
+
+// cleanLine is the message printed when the gate lets a build through.
+func cleanLine(results []scan.Result) string {
+	if allSkipped(results) {
+		return Dim("Scanning disabled — all packages skipped.")
+	}
+	return Green("All scanned packages look clean.") +
+		Dim("  (heuristic scan — not a guarantee)")
+}
+
 // autoPass reports whether results may proceed without any prompt. A non-OK
 // verdict never auto-passes. In strict mode (the unattended build-hook path) a
 // fallback-produced OK does not auto-pass either: the primary scanner was
 // unavailable, so a degraded clean verdict still requires confirmation.
 func autoPass(results []scan.Result, strict bool) bool {
 	for _, r := range results {
-		if r.V.Verdict != "OK" {
+		if r.V.Verdict != "OK" && r.V.Verdict != "SKIPPED" {
 			return false
 		}
 		if strict && r.Fallback {
@@ -87,7 +110,7 @@ func autoPass(results []scan.Result, strict bool) bool {
 func flaggedSet(results []scan.Result, strict bool) []scan.Result {
 	var out []scan.Result
 	for _, r := range results {
-		if r.V.Verdict != "OK" || (strict && r.Fallback) {
+		if (r.V.Verdict != "OK" && r.V.Verdict != "SKIPPED") || (strict && r.Fallback) {
 			out = append(out, r)
 		}
 	}
@@ -159,8 +182,7 @@ func Decide(results []scan.Result, strict bool) bool {
 	summarize(results)
 	w := TerminalWidth()
 	if autoPass(results, strict) {
-		fmt.Println(Green("All scanned packages look clean.") +
-			Dim("  (heuristic scan — not a guarantee)"))
+		fmt.Println(cleanLine(results))
 		return true
 	}
 	fmt.Printf("%s%s\n", Red(Bold("!! aurscan blocked this build: ")),
@@ -221,8 +243,7 @@ func Gate(results []scan.Result, strict bool) bool {
 
 	w := TerminalWidth()
 	if autoPass(results, strict) {
-		fmt.Println(Green("All scanned packages look clean.") +
-			Dim("  (heuristic scan — not a guarantee)"))
+		fmt.Println(cleanLine(results))
 		return true
 	}
 

--- a/internal/ui/gate.go
+++ b/internal/ui/gate.go
@@ -44,6 +44,10 @@ func VerdictBadge(verdict string) string {
 
 func printVerdict(r scan.Result) {
 	badge := VerdictBadge(r.V.Verdict)
+	if r.V.Verdict == "SKIPPED" {
+		fmt.Printf("[%s] %s - %s\n", badge, Bold(r.Pkg), r.V.Summary)
+		return
+	}
 	meta := fmt.Sprintf("confidence %.0f%%", r.V.Confidence)
 	if r.Cached {
 		meta += ", cached"
@@ -201,6 +205,10 @@ func Decide(results []scan.Result, strict bool) bool {
 func GateVia(results []scan.Result, in io.Reader, out io.Writer, strict bool) bool {
 	w := TerminalWidth()
 	for _, r := range results {
+		if r.V.Verdict == "SKIPPED" {
+			fmt.Fprintf(out, "[%s] %s - %s\n", VerdictBadge(r.V.Verdict), r.Pkg, r.V.Summary)
+			continue
+		}
 		fmt.Fprintf(out, "[%s] %s (confidence %.0f%%)\n",
 			VerdictBadge(r.V.Verdict), r.Pkg, r.V.Confidence)
 		if r.V.Summary != "" {

--- a/internal/ui/progress_test.go
+++ b/internal/ui/progress_test.go
@@ -1,0 +1,55 @@
+package ui
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// captureStdout redirects os.Stdout for the duration of the test and returns
+// a func that closes the pipe and returns everything printed so far.
+func captureStdout(t *testing.T) func() string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	t.Cleanup(func() {
+		w.Close()
+		os.Stdout = old
+	})
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+	return func() string {
+		w.Close()
+		return <-done
+	}
+}
+
+// TestProgressSilentWhenDisabled proves the kill switch silences the
+// "scanning ..." announce: with AURSCAN_DISABLE=1 nothing is scanned, so
+// nothing is printed.
+func TestProgressSilentWhenDisabled(t *testing.T) {
+	t.Setenv("AURSCAN_DISABLE", "1")
+	got := captureStdout(t)
+	Progress("evilpkg", 3)
+	if out := got(); out != "" {
+		t.Fatalf("Progress printed %q while scanning is disabled", out)
+	}
+}
+
+// TestProgressPrintsWhenEnabled pins the announce for a real scan.
+func TestProgressPrintsWhenEnabled(t *testing.T) {
+	t.Setenv("AURSCAN_DISABLE", "")
+	got := captureStdout(t)
+	Progress("evilpkg", 3)
+	if out := got(); !strings.Contains(out, "scanning evilpkg (3 files)") {
+		t.Fatalf("Progress output = %q, want the scanning line", out)
+	}
+}

--- a/internal/yay/paru.go
+++ b/internal/yay/paru.go
@@ -208,7 +208,7 @@ func PrebuildHook(args []string) {
 	res := pipeline.Run(name, files, "")
 	results := []scan.Result{res}
 
-	if res.V.Verdict == "OK" && !res.Fallback {
+	if (res.V.Verdict == "OK" || res.V.Verdict == "SKIPPED") && !res.Fallback {
 		ui.Decide(results, true) // prints the clean line
 		os.Exit(0)
 	}

--- a/internal/yay/paru.go
+++ b/internal/yay/paru.go
@@ -186,12 +186,12 @@ func UninstallParuHook() (string, bool, error) {
 }
 
 // PrebuildHook is the `aurscan --prebuild <dir>` entrypoint paru invokes via
-// PreBuildCommand. It scans the directory and, on a non-OK verdict, lets the
+// PreBuildCommand. It scans the directory and, on an adverse verdict, lets the
 // user decide interactively. Because paru runs PreBuildCommand with redirected
 // stdio, the prompt is done over /dev/tty (the controlling terminal) rather
 // than stdin/stdout — this is what makes the interactive build decision work
 // under paru (issue #3). With no controlling terminal (CI, non-interactive),
-// it fails closed: any non-OK verdict aborts the build via a non-zero exit.
+// it fails closed: any adverse verdict aborts the build via a non-zero exit.
 func PrebuildHook(args []string) {
 	dir := "."
 	if len(args) > 0 {
@@ -199,6 +199,10 @@ func PrebuildHook(args []string) {
 	}
 	abs, _ := filepath.Abs(dir)
 	name := filepath.Base(abs)
+	if pipeline.Disabled() {
+		ui.Decide([]scan.Result{pipeline.SkippedResult(name)}, true)
+		os.Exit(0)
+	}
 	files, err := scan.CollectDir(dir)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, ui.Red("aurscan: ")+err.Error()+" (fail-closed)")

--- a/internal/yay/yay.go
+++ b/internal/yay/yay.go
@@ -211,6 +211,10 @@ func EditHook(paths []string) {
 	var results []scan.Result
 	for d := range dirs {
 		name := filepath.Base(d)
+		if pipeline.Disabled() {
+			results = append(results, pipeline.SkippedResult(name))
+			continue
+		}
 		files, err := scan.CollectDir(d)
 		if err != nil {
 			results = append(results, scan.Result{


### PR DESCRIPTION
## What

Adds `AURSCAN_DISABLE=1`, a build-hook and plain-scan kill switch. Disabled packages receive an immediate `SKIPPED` verdict and pass through with exit `0`; no directory collection, AUR lookup/snapshot fetch, static rules, or model call runs.

`--score` is deliberately different: it is an explicit scoring query, ignores `AURSCAN_DISABLE`, and always produces a real score.

```console
$ AURSCAN_DISABLE=1 aurscan ./pkg
[SKIPPED] pkg - scanning disabled (AURSCAN_DISABLE=1)

Scanning disabled — all packages skipped.
```

## Why

- Re-run an interrupted build without re-scanning unchanged package sources.
- Skip expected hash-only changes without filesystem, network, or model overhead.
- Let users opt out without uninstalling the yay/paru hooks.

## How

The early exits are at the actual work boundaries: standalone scans skip before `CollectDir`, recursive AUR scans skip before RPC/snapshot access, and yay/paru hooks skip before directory collection. `pipeline.Run` retains a defence-in-depth gate; `RunScored` bypasses it for `--score`.

`SKIPPED` has a dimmed badge, an inline disabled message, and is explicitly allowed through the gates/hooks. It is not a trust verdict, so `--score` never emits it.

## Verification

- `make test` (`go vet ./...` and `go test ./...`) clean
- Disabled standalone empty directory: `SKIPPED`, exit `0`, no collection error
- Disabled paru prebuild empty directory: `SKIPPED`, exit `0`, no collection error
- Disabled yay editor-hook against an uncollectable package root: `SKIPPED`, exits cleanly and chains to `/bin/true`
- `AURSCAN_DISABLE=1 AURSCAN_RULES_ONLY=1 aurscan --score ./PKGBUILD`: real score `80`, exit `80`

PR template not found, looked in: `.github/pull_request_template.md`, `.github/PULL_REQUEST_TEMPLATE/*.md`.